### PR TITLE
Feature: write requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ gradle/*
 gradlew
 gradlew.bat
 .vscode/*
+log.txt

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ Authors:
 - Run the application with gradle (if gradle is in the environment variables): `gradle run`
 
 ## Architectural choices
-- Both replicas and clients hold a list of all the replicas in the system
-    - Replicas need to know which are the other replicas
-    - Clients pick the replica to contact from that list. Each client has a
-    favourite replica and keeps contacting it until it crashes. When that happens,
-    it pick another one
+
+- Both replicas and clients hold a list of all the replicas in the system:
+
+  - Replicas need to know which are the other replicas
+  - Clients pick the replica to contact from that list. Each client has a
+    favorite replica and keeps contacting it until it crashes. When that happens,
+    it picks another one
 
 - Initially the coordinator is the first replica created

--- a/src/main/java/it/unitn/ds1/Broadcaster.java
+++ b/src/main/java/it/unitn/ds1/Broadcaster.java
@@ -1,10 +1,11 @@
 package it.unitn.ds1;
+
 import java.io.IOException;
 import java.util.ArrayList;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import it.unitn.ds1.Replica.JoinGroupMsg;
+import it.unitn.ds1.models.JoinGroupMsg;
 
 public class Broadcaster {
   final static int N_CLIENTS = 5;
@@ -32,9 +33,8 @@ public class Broadcaster {
     System.out.println(">>> Press ENTER to exit <<<");
     try {
       System.in.read();
-    }
-    catch (IOException ioe) {}
-    finally {
+    } catch (IOException ioe) {
+    } finally {
       system.terminate();
     }
   }

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -1,6 +1,5 @@
 package it.unitn.ds1;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -9,6 +8,9 @@ import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.Cancellable;
 import akka.actor.Props;
+import it.unitn.ds1.models.ReadMsg;
+import it.unitn.ds1.models.ReadOkMsg;
+import it.unitn.ds1.models.WriteMsg;
 import scala.concurrent.duration.Duration;
 
 public class Client extends AbstractActor {
@@ -58,26 +60,6 @@ public class Client extends AbstractActor {
         }
 
         return this.replicas.get(this.favoriteReplica);
-    }
-
-    //--------------------------------------------------------------------------
-
-    public static class WriteMsg implements Serializable {
-        public final int v;
-
-        public WriteMsg(int v) {
-            this.v = v;
-        }
-    }
-
-    public static class ReadMsg implements Serializable {}
-
-    public static class ReadOkMsg implements Serializable {
-        public final int v;
-
-        public ReadOkMsg(int v) {
-            this.v = v;
-        }
     }
 
     //--------------------------------------------------------------------------

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -25,7 +25,7 @@ public class Client extends AbstractActor {
         this.replicas = replicas;
         this.v = 0;
         this.favoriteReplica = -1;
-        this.numberGenerator = new Random();
+        this.numberGenerator = new Random(System.nanoTime());
     }
 
     public static Props props(ArrayList<ActorRef> replicas) {
@@ -51,6 +51,9 @@ public class Client extends AbstractActor {
                 new UpdateRequestMsg(this.numberGenerator.nextInt(MAX_INT)),
                 getContext().system().dispatcher(),
                 getSelf());
+        // this.replicas.get(numberGenerator.nextInt(replicas.size()))
+        // .tell(new UpdateRequestMsg(this.numberGenerator.nextInt(MAX_INT)),
+        // getSelf());
     }
 
     private ActorRef getReplica() {

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -10,7 +10,7 @@ import akka.actor.Cancellable;
 import akka.actor.Props;
 import it.unitn.ds1.models.ReadMsg;
 import it.unitn.ds1.models.ReadOkMsg;
-import it.unitn.ds1.models.WriteMsg;
+import it.unitn.ds1.models.UpdateRequestMsg;
 import scala.concurrent.duration.Duration;
 
 public class Client extends AbstractActor {
@@ -36,22 +36,21 @@ public class Client extends AbstractActor {
     public void preStart() {
         // Create a timer that will periodically send a message to a replica
         Cancellable readTimer = getContext().system().scheduler().scheduleWithFixedDelay(
-            Duration.create(1, TimeUnit.SECONDS),   // when to start generating messages
-            Duration.create(1, TimeUnit.SECONDS),   // how frequently generate them
-            this.getReplica(),                      // destination actor reference
-            new ReadMsg(),                          // the message to send
-            getContext().system().dispatcher(),     // system dispatcher
-            getSelf()                               // source of the message (myself)
+                Duration.create(1, TimeUnit.SECONDS), // when to start generating messages
+                Duration.create(1, TimeUnit.SECONDS), // how frequently generate them
+                this.getReplica(), // destination actor reference
+                new ReadMsg(), // the message to send
+                getContext().system().dispatcher(), // system dispatcher
+                getSelf() // source of the message (myself)
         );
 
         Cancellable writeTimer = getContext().system().scheduler().scheduleWithFixedDelay(
-            Duration.create(1, TimeUnit.SECONDS),
-            Duration.create(1, TimeUnit.SECONDS),
-            this.getReplica(),
-            new WriteMsg(this.numberGenerator.nextInt(MAX_INT)),
-            getContext().system().dispatcher(),
-            getSelf()
-        );
+                Duration.create(1, TimeUnit.SECONDS),
+                Duration.create(1, TimeUnit.SECONDS),
+                this.getReplica(),
+                new UpdateRequestMsg(this.numberGenerator.nextInt(MAX_INT)),
+                getContext().system().dispatcher(),
+                getSelf());
     }
 
     private ActorRef getReplica() {
@@ -62,7 +61,7 @@ public class Client extends AbstractActor {
         return this.replicas.get(this.favoriteReplica);
     }
 
-    //--------------------------------------------------------------------------
+    // --------------------------------------------------------------------------
 
     private void onReadOk(ReadOkMsg msg) {
         // Updates client value with the one read from a replica
@@ -73,8 +72,8 @@ public class Client extends AbstractActor {
     @Override
     public Receive createReceive() {
         return receiveBuilder()
-            .match(ReadOkMsg.class, this::onReadOk)
-            .build();
+                .match(ReadOkMsg.class, this::onReadOk)
+                .build();
     }
-    
+
 }

--- a/src/main/java/it/unitn/ds1/Replica.java
+++ b/src/main/java/it/unitn/ds1/Replica.java
@@ -8,9 +8,9 @@ import java.util.List;
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.Props;
-import it.unitn.ds1.Client.ReadMsg;
-import it.unitn.ds1.Client.ReadOkMsg;
-import it.unitn.ds1.Client.WriteMsg;
+import it.unitn.ds1.models.ReadMsg;
+import it.unitn.ds1.models.ReadOkMsg;
+import it.unitn.ds1.models.WriteMsg;
 
 public class Replica extends AbstractActor {
     private final List<ActorRef> replicas;
@@ -65,6 +65,17 @@ public class Replica extends AbstractActor {
 
     @Override
     public Receive createReceive() {
+        return receiveBuilder()
+            .match(JoinGroupMsg.class,  this::onJoinGroupMsg)
+            .match(WriteMsg.class, this::onWriteMsg)
+            .match(ReadMsg.class, this::onReadMsg)
+            .build();
+    }
+
+    /**
+     * Create a new coordinator replica, similar to the other replicas, but can handle updates
+     */
+    public Receive createCoordinator() {
         return receiveBuilder()
             .match(JoinGroupMsg.class,  this::onJoinGroupMsg)
             .match(WriteMsg.class, this::onWriteMsg)

--- a/src/main/java/it/unitn/ds1/Replica.java
+++ b/src/main/java/it/unitn/ds1/Replica.java
@@ -1,7 +1,13 @@
 package it.unitn.ds1;
 
+import java.io.Serializable;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
@@ -10,15 +16,27 @@ import it.unitn.ds1.models.JoinGroupMsg;
 import it.unitn.ds1.models.ReadMsg;
 import it.unitn.ds1.models.ReadOkMsg;
 import it.unitn.ds1.models.UpdateRequestMsg;
+import it.unitn.ds1.models.WriteAckMsg;
+import it.unitn.ds1.models.WriteMsg;
+import it.unitn.ds1.models.WriteOkMsg;
 
 public class Replica extends AbstractActor {
     private final List<ActorRef> replicas;
     private int coordinatorIndex;
     private boolean isCoordinator;
-    private int v;
-    private int quorum = 0;
+
+    private int v; // The value of the replica
+
+    private int quorum = 0; // The number of nodes that must agree on a write
+    private int epoch; // The current epoch
+    private int writeIndex; // The index of the last write operation
+
+    private final Map<Map.Entry<Integer, Integer>, Set<ActorRef>> writeAcksMap = new HashMap<>(); // The number of  write acks received for each write
+
+    private final Map<Map.Entry<Integer, Integer>, Integer> writeRequests = new HashMap<>(); // The write requests the replica has received from the coordinator, the value is the new value to write
 
     public Replica(int v, int coordinatorIndex) {
+        System.out.println("Replica created with value " + v);
         this.replicas = new ArrayList<>();
         this.coordinatorIndex = coordinatorIndex;
         this.isCoordinator = false;
@@ -41,20 +59,98 @@ public class Replica extends AbstractActor {
         System.out.println();
     }
 
+    private void multicast(Serializable msg) {
+        for (ActorRef replica : this.replicas) {
+            replica.tell(msg, this.self());
+        }
+    }
+
     private void onUpdateRequest(UpdateRequestMsg msg) {
         // If the replica is not the coordinator
         if (!this.isCoordinator) {
             // Send the request to the coordinator
             var coordinator = this.replicas.get(this.coordinatorIndex);
             coordinator.tell(msg, this.self());
+            this.writeIndex++;
             return;
         }
 
-        // Implement the quorum protocol. The coordinator asks all the replicas if
-        System.out.println("Client " + getSender().path().name() + " wr9te req to " + this.getSelf().path().name()
-                + " for " + msg.v);
+        // The coordinator is requesting to itself
+        if (getSender().path().uid() == this.getSelf().path().uid())
+            return;
+
+        // Implement the quorum protocol. The coordinator asks all the replicas to
+        // update
+        multicast(new WriteMsg(msg.v, this.epoch, this.writeIndex));
+        this.writeIndex++;
+
+        System.out.println("Client " + getSender().path().name() + " wr9te req to " + this.getSelf().path().name() + " for " + msg.v + " in epoch " + this.epoch + " with index " + this.writeIndex);
     }
 
+    private void onWriteAckMsg(WriteAckMsg msg) {
+        if (!this.isCoordinator)
+            return;
+
+        // If the epoch of the write is not the current epoch, ignore the message
+        if (msg.epoch != this.epoch)
+            return;
+
+        // If the pair epoch-index is not in the map, add the list
+        var pair = new AbstractMap.SimpleEntry<>(msg.epoch, msg.writeIndex);
+        this.writeAcksMap.putIfAbsent(pair, new HashSet<>());
+
+        // Add the sender to the list
+        this.writeAcksMap.get(pair).add(getSender());
+
+        // If the quorum has been reached, remove the pair from the map and send the
+        // WriteOk message
+        if (this.writeAcksMap.get(pair).size() >= this.quorum) {
+            this.writeAcksMap.remove(pair);
+            multicast(new WriteOkMsg(msg.epoch, msg.writeIndex));
+        }
+
+        System.out.println("Received ack from " + getSender().path().name() + " for " + msg.writeIndex + " in epoch " + msg.epoch);
+    }
+
+    /**
+     * The coordinator is requesting to write a new value to the replicas
+     */
+    private void onWriteMsg(WriteMsg msg) {
+        // Add the request to the list, so that it is ready if the coordinator requests
+        // the update
+        this.writeRequests.put(new AbstractMap.SimpleEntry<>(msg.epoch, msg.writeIndex), msg.v);
+        // Send the acknowledgement to the coordinator
+        getSender().tell(new WriteAckMsg(msg.epoch, msg.writeIndex), this.self());
+        // Increase the write index
+
+        System.out.println("Write requested by the coordinator " + getSender().path().name() + " to "
+                + this.getSelf().path().name() + " for " + msg.v);
+    }
+
+    /**
+     * The coordinator sent the write ok message, so the replicas can apply the
+     * write
+     */
+    private void onWriteOkMsg(WriteOkMsg msg) {
+        // If the epoch of the write is not the current epoch, ignore the message
+        if (msg.epoch != this.epoch)
+            return;
+
+        // If the pair epoch-index is not in the map, ignore the message
+        var pair = new AbstractMap.SimpleEntry<>(msg.epoch, msg.writeIndex);
+        if (!this.writeRequests.containsKey(pair))
+            return;
+
+        // Apply the write
+        this.v = this.writeRequests.get(pair);
+        this.writeRequests.remove(pair);
+
+        System.out.println("Applied the write " + msg.writeIndex + " in epoch " + msg.epoch + " with value " + this.v);
+    }
+
+    /**
+     * The client is requesting to read the value of the replica
+     */
     private void onReadMsg(ReadMsg msg) {
         ActorRef sender = getSender();
         sender.tell(new ReadOkMsg(this.v), this.self());
@@ -64,24 +160,29 @@ public class Replica extends AbstractActor {
 
     @Override
     public Receive createReceive() {
-        if (this.isCoordinator)
-            return createCoordinator();
         return receiveBuilder()
                 .match(JoinGroupMsg.class, this::onJoinGroupMsg)
-                .match(UpdateRequestMsg.class, this::onUpdateRequest)
                 .match(ReadMsg.class, this::onReadMsg)
+                .match(UpdateRequestMsg.class, this::onUpdateRequest)
+                .match(WriteAckMsg.class, this::onWriteAckMsg)
+                .match(WriteMsg.class, this::onWriteMsg)
+                .match(WriteOkMsg.class, this::onWriteOkMsg)
                 .build();
     }
 
     /**
      * Create a new coordinator replica, similar to the other replicas, but can
      * handle updates
+     * [This seems to be useless for now]
      */
     public Receive createCoordinator() {
         return receiveBuilder()
                 .match(JoinGroupMsg.class, this::onJoinGroupMsg)
-                .match(UpdateRequestMsg.class, this::onUpdateRequest)
                 .match(ReadMsg.class, this::onReadMsg)
+                .match(UpdateRequestMsg.class, this::onUpdateRequest)
+                .match(WriteAckMsg.class, this::onWriteAckMsg)
+                .match(WriteMsg.class, this::onWriteMsg)
+                .match(WriteOkMsg.class, this::onWriteOkMsg)
                 .build();
     }
 }

--- a/src/main/java/it/unitn/ds1/models/JoinGroupMsg.java
+++ b/src/main/java/it/unitn/ds1/models/JoinGroupMsg.java
@@ -1,0 +1,17 @@
+package it.unitn.ds1.models;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import akka.actor.ActorRef;
+
+public class JoinGroupMsg implements Serializable {
+    // List of all replicas in the system
+    public final List<ActorRef> replicas;
+
+    public JoinGroupMsg(ArrayList<ActorRef> group) {
+        this.replicas = Collections.unmodifiableList(new ArrayList<>(group));
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/ReadMsg.java
+++ b/src/main/java/it/unitn/ds1/models/ReadMsg.java
@@ -1,0 +1,10 @@
+package it.unitn.ds1.models;
+
+import java.io.Serializable;
+
+/**
+ * Sent by the client to the replica, to read the value
+ */
+public class ReadMsg implements Serializable {
+    
+}

--- a/src/main/java/it/unitn/ds1/models/ReadOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/ReadOkMsg.java
@@ -1,0 +1,14 @@
+package it.unitn.ds1.models;
+
+import java.io.Serializable;
+
+/**
+ * Sent by the replica to the client, in response to a READ request
+ */
+public class ReadOkMsg implements Serializable {
+    public final int v;
+
+    public ReadOkMsg(int v) {
+        this.v = v;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/UpdateRequestMsg.java
+++ b/src/main/java/it/unitn/ds1/models/UpdateRequestMsg.java
@@ -1,0 +1,14 @@
+package it.unitn.ds1.models;
+
+import java.io.Serializable;
+
+/**
+ * Sent by the client to the replica, to update the value.
+ */
+public class UpdateRequestMsg implements Serializable {
+    public final int v;
+
+    public UpdateRequestMsg(int v) {
+        this.v = v;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/WriteAckMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteAckMsg.java
@@ -1,0 +1,10 @@
+package it.unitn.ds1.models;
+
+import java.io.Serializable;
+
+/**
+ * Sent by the replicas, to acknowledge the write operation requested by the coordinator.
+ */
+public class WriteAckMsg implements Serializable {
+    
+}

--- a/src/main/java/it/unitn/ds1/models/WriteAckMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteAckMsg.java
@@ -6,5 +6,11 @@ import java.io.Serializable;
  * Sent by the replicas, to acknowledge the write operation requested by the coordinator.
  */
 public class WriteAckMsg implements Serializable {
-    
+    public final int epoch; // Epoch of the coordinator
+    public final int writeIndex; // Index of the write operation
+
+    public WriteAckMsg(int epoch, int writeIndex) {
+        this.epoch = epoch;
+        this.writeIndex = writeIndex;
+    }
 }

--- a/src/main/java/it/unitn/ds1/models/WriteMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteMsg.java
@@ -3,12 +3,16 @@ package it.unitn.ds1.models;
 import java.io.Serializable;
 
 /**
- * Sent by the
+ * Sent by the coordinator, to write a new value to the replicas.
  */
 public class WriteMsg implements Serializable {
-    public final int v;
+    public final int v; // The new value to write
+    public final int epoch; // The epoch (current coordinator)
+    public final int writeIndex; // The index of the write operation
 
-    public WriteMsg(int v) {
+    public WriteMsg(int v, int e, int i) {
         this.v = v;
+        this.epoch = e;
+        this.writeIndex = i;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/WriteMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteMsg.java
@@ -1,0 +1,14 @@
+package it.unitn.ds1.models;
+
+import java.io.Serializable;
+
+/**
+ * Sent by the client to the replica, to update the value
+ */
+public class WriteMsg implements Serializable {
+    public final int v;
+
+    public WriteMsg(int v) {
+        this.v = v;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/WriteMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteMsg.java
@@ -3,7 +3,7 @@ package it.unitn.ds1.models;
 import java.io.Serializable;
 
 /**
- * Sent by the client to the replica, to update the value
+ * Sent by the
  */
 public class WriteMsg implements Serializable {
     public final int v;

--- a/src/main/java/it/unitn/ds1/models/WriteOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteOkMsg.java
@@ -6,4 +6,11 @@ import java.io.Serializable;
  * Sent by the coordinator, to apply the write operation.
  */
 public class WriteOkMsg implements Serializable {
+    public final int epoch; // The epoch of the coordinator
+    public final int writeIndex; // The index of the write operation
+
+    public WriteOkMsg(int epoch, int writeIndex) {
+        this.epoch = epoch;
+        this.writeIndex = writeIndex;
+    }
 }

--- a/src/main/java/it/unitn/ds1/models/WriteOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteOkMsg.java
@@ -1,0 +1,9 @@
+package it.unitn.ds1.models;
+
+import java.io.Serializable;
+
+/**
+ * Sent by the coordinator, to apply the write operation.
+ */
+public class WriteOkMsg implements Serializable {
+}


### PR DESCRIPTION
Upon receiving a write request, a replica should contact the Coordinator to request the update.
The Coordinator should then send a WriteMsg to all replicas, wait for the majority of them to acknowledge, and then apply the update with a WriteOkMsg.

In case the quorum is not reached, the message is not sent.

Note: in the current design, if a message doesn't reach the quorum, then none of the successive message will be applied, because of the FIFO rule. Based on assumptions that majority of node CANNOT crash at the same time, this shouldn't happen. 
In any case, this FIFO part can be discarded with a rollback of commit f2b508573bc382ca0fbffd89a4d069f3a1dea518.

Note 2: there is no check for FIFO when applying an update, should this be a concern?