### PR TITLE
Crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,98 @@ reset this time of last contact
 - Press `ENTER` again to send a stop signal to clients forcing them to stop
 producing more requests
 - Press `ENTER` a third time to terminate the system
+
+## Crash detection protocol
+Crash detection works by means of periodic checks of arrival of messages.
+
+### Detection of crashed replicas by clients
+- Read requests: `ReadMsg`
+
+  Each clients identifies univocally a read request by means of an incrementing
+  index that's placed withing the request itself. Upon sending the request to a
+  replica, the client registers the sent request into `readMsgs` (maps read
+  indexes to replicas) and starts a timeout (`READOK_TIMEOUT`). When the
+  timeout expires a `ReadOkReceivedMsg` is sent by the client to itself.
+
+  A client expects to receive a `ReadOkMsg` from the contacted replica and that
+  message should contain the read value and the Id of the served read request. On
+  arrival, the client removes from `readMsgs` the request with the ID found in
+  the `ReadOkMsg`. A `ReadOkReceivedMsg` also contains the ID of the associated
+  request and the handler checks if `readMsgs` holds a value. If that's the case,
+  then it means that no `ReadOkMsg` has been received so the replica found in the
+  map associated to that ID is presumed to be crashed and removed from the list
+  of active replicas. Otherwise, if the map has no value it means that the
+  request has been served and the replica was fine up to that point.
+
+- Update requests: `UpdateRequestMsg`
+
+  An update request is identified by the `ActorRef` of the client and another
+  incrementing ID. Such pair is handled by the `UpdateRequestId` class. As for
+  read requests, when a client sends un update to a replica, it registers the
+  request and the destination replica in a map (`writeMsgs`) using the ID as key
+  and starts a timeout (`UpdateRequestOkReceivedMsg`).
+
+  The replica, once the request has been served, responds with an
+  `UpdateRequestOkMsg` holding the index of the served request. On arrival, the
+  index found is used to remove the associated value from `writeMsgs` and on
+  arrival of the corresponding `UpdateRequestOkMsg` the same check done for
+  read requests is performed. So, a no-value means that the request has been
+  served and otherwise that the contacted replica has taken too long to answer
+  and is identified as crashed.
+
+  On replica side, when an update request is received the ID (pair `<client, index>`)
+  is saved in the set `updateRequests`. This ID is also put into all associated
+  `WriteMsg`s and `WriteOkMsg`s. When the update protocol terminates and a
+  replica receives a `WriteOkMSg`, it takes the update request ID carried by the
+  message and checks if it is present into `updateRequests`. If that's the case,
+  it means that this replica is the one that has received the request from the
+  client and thus it has to send back an ACK, namely an `UpdateRequestOkMsg` to
+  that client. This message holds the local update request index of that client.
+
+### Detection of crashed coordinator by replicas
+
+- On update requests: `UpdateRequestMsg`
+
+  When a replica that's not the coordinator receives an update request, forwards
+  it to the coordinator and expects to recive back a `WriteMsg`. So, upon forwarding
+  the request the replica start a timeout (`WRITEMSG_TIMEOUT`) and registers the
+  ID of the request into the `pendingUpdateRequests` set.
+
+  When the coordinator sends a `WriteMsg` it embeds in it the `updateRequestId` of
+  the update request that's being served. Upon reception of this message by the
+  coordinator, a replica removes the `updateRequestId` from `pendingUpdateRequests`
+  and adds the `WriteId` of the message into `writeRequests` to register the serving
+  of that write request.
+
+  When `WRITEMSG_TIMEOUT` expires a `WriteMsgReceivedMsg` is sent by the replica to
+  itself and if the expected `WriteMsg` has not been received, so if
+  `pendingUpdateRequests` has `updateRequestId` in it, the coordinator is considered
+  to be crashed. Alive, otherwise.
+
+  On coordinator side, when an `UpdateRequestMsg` is received, the association
+  `WriteId->UpdateRequestId`, `WriteId` being a class representing the pair
+  `<epoch, write_index>`, is saved into `writesToUpates` maps and is later used
+  to build the `WriteOkMsg`s.
+
+- On write message: `WriteMsg`
+
+  When a replica receives a `WriteMsg` it sends an ACK back to the coordinator
+  and expects to receive a `WriteOkMsg` in response. So, again a timer
+  (`WRITEOK_TIMEOUT`) is set and a `WriteOkReceivedMSg` is sent by a replica to
+  itself at expiration. On receipt of a `WriteOk`, the associated `WriteId` is
+  removed from `writeRequests` and on receipt of `WriteOkRecivedMsg` the same
+  kind of cheks done for the others `ReceivedMsg`s is done. So, if `writeRequests`
+  still holds `WriteId`, the request has not been served yet, and the coordinator
+  is set to crashed.
+
+  On coordinator side, when enough ACKs are received for a request and the
+  corresponing `WriteOkMsg` can be sent, the `WriteId` associated by current
+  values for `epoch` and `currentWriteToAck` is used to retrive from
+  `writesToUpdates` to `UpdateRequestId` of originating request and such ID is
+  put into the `WriteOk`.
+
+### Detection of crashed replicas by coordinator
+- On ACK message: `WriteAckMsg`
+
+  Thanks to the assumption on the minimum available number of a replicas, no
+  crash check needs to be perfomed by coordinator side on recipt of ACK messages.

--- a/README.md
+++ b/README.md
@@ -21,19 +21,23 @@ Authors:
 ## Architectural choices
 
 - Both replicas and clients hold a list of all the replicas in the system:
-
   - Replicas need to know which are the other replicas
   - Clients pick the replica to contact from that list. Each client has a
     favorite replica and keeps contacting it until it crashes. When that happens,
     it picks another one
-
 - Initially the coordinator is the first replica created
+- Replicas keep track of the last time they heard anythig from the coordinator.
+HearbetMsg and any other kind of message received from the coordinator makes them
+reset this time of last contact
 
 ## Running the system
 - Start the system with `gradle run`
   Replicas and clients are created
-- Press `ENTER` to send a start signal to clients and crash manager so that they
-begin producing request for replicas
+- Press `ENTER` to send a start signal to all hosts:
+  - Clients begin sending requests to replicas
+  - Replicas begin expecting heartbeat messages (or ay kind of message) from the
+  coordinator
+  - Coordinator begin sending heartbeat messages to replicas
 - Press `ENTER` again to send a stop signal to clients forcing them to stop
 producing more requests
 - Press `ENTER` a third time to terminate the system

--- a/src/main/java/it/unitn/ds1/Broadcaster.java
+++ b/src/main/java/it/unitn/ds1/Broadcaster.java
@@ -37,7 +37,13 @@ public class Broadcaster {
         ActorRef crashManager = system.actorOf(CrashManager.props(replicas), "crash_manager");
 
         System.out.print(">>> System ready");
-        requestContinue(system, "send start signal to clients and crash manager");
+        requestContinue(system, "send start signal to all hosts");
+
+        // Send StartMsg to replicas so that they begin sending HeartbeatMsg
+        // (coordinator) and start their timer for heartbeatMsg (replicas)
+        for (ActorRef replica : replicas) {
+            replica.tell(new StartMsg(), ActorRef.noSender());
+        }
 
         // Send StartMsg to clients so that they begin producing requests
         for (ActorRef client : clients) {

--- a/src/main/java/it/unitn/ds1/Broadcaster.java
+++ b/src/main/java/it/unitn/ds1/Broadcaster.java
@@ -2,9 +2,9 @@ package it.unitn.ds1;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import it.unitn.ds1.models.JoinGroupMsg;
-import it.unitn.ds1.models.StartMsg;
-import it.unitn.ds1.models.StopMsg;
+import it.unitn.ds1.models.administratives.JoinGroupMsg;
+import it.unitn.ds1.models.administratives.StartMsg;
+import it.unitn.ds1.models.administratives.StopMsg;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/it/unitn/ds1/Broadcaster.java
+++ b/src/main/java/it/unitn/ds1/Broadcaster.java
@@ -10,8 +10,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 public class Broadcaster {
-    final static int N_CLIENTS = 3;
-    final static int N_REPLICAS = 5;
+    final static int N_CLIENTS = 2;
+    final static int N_REPLICAS = 4;
 
     public static void main(String[] args) {
         final ActorSystem system = ActorSystem.create("project");

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -1,6 +1,8 @@
 package it.unitn.ds1;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -13,15 +15,28 @@ import it.unitn.ds1.models.ReadOkMsg;
 import it.unitn.ds1.models.StartMsg;
 import it.unitn.ds1.models.StopMsg;
 import it.unitn.ds1.models.UpdateRequestMsg;
+import it.unitn.ds1.models.UpdateRequestOkMsg;
+import it.unitn.ds1.models.crash_detection.ReadOkReceivedMsg;
+import it.unitn.ds1.models.crash_detection.UpdateRequestOkReceivedMsg;
 import scala.concurrent.duration.Duration;
 
 public class Client extends AbstractActor {
     // Maximum value to be generated for update messages
     static final int MAX_INT = 1000;
 
+    // Timeout for receipt of confirmation for a read request before considering
+    // the contacted replica, crashed
+    static final long READOK_TIMEOUT = 1000;
+    private final long UPDATE_REQUEST_OK_TIMEOUT;
+
     private final ArrayList<ActorRef> replicas; // All replicas in the system
     private int v; // Last read value
-    private int favoriteReplica;
+    private int readIndex;
+    private int writeIndex;
+    // These two sets are used to track requests sent and waiting for ACK
+    private final Map<Integer, ActorRef> readMsgs;
+    private final Map<Integer, ActorRef> writeMsgs;
+
     private final Random numberGenerator;
 
     private Cancellable readTimer;
@@ -30,8 +45,16 @@ public class Client extends AbstractActor {
     public Client(ArrayList<ActorRef> replicas) {
         this.replicas = replicas;
         this.v = 0;
-        this.favoriteReplica = -1;
+        this.readIndex = 0;
+        this.writeIndex = 0;
+        this.readMsgs = new HashMap<>();
+        this.writeMsgs = new HashMap<>();
         this.numberGenerator = new Random(System.nanoTime());
+
+        // Sets timeout to maximum delay
+        this.UPDATE_REQUEST_OK_TIMEOUT =
+            Replica.DELAY * 3 + Replica.DELAY * 2 * this.replicas.size() +
+            Replica.DELAY * 5; // For additional safety;
 
         System.out.printf("[C] Client %s created\n", getSelf().path().name());
     }
@@ -41,44 +64,37 @@ public class Client extends AbstractActor {
     }
 
     /**
-     * Return the replica to be contacted. If favorite replica is available, it
-     * is returned, otherwise another random one is chosen and set as favorite.
+     * Return the replica to be contacted. Is randomly chosen each time.
      * @return replica to be contacted
      */
     private ActorRef getReplica() {
-        if (this.favoriteReplica < 0) {
-            this.favoriteReplica = this.numberGenerator.nextInt(this.replicas.size());
-        }
-
-        System.out.printf(
-            "[C] Client %s chose replica %s as favorite\n",
-            getSelf().path().name(),
-            this.replicas.get(this.favoriteReplica).path().name()
-        );
-        return this.replicas.get(this.favoriteReplica);
+        int index = this.numberGenerator.nextInt(1, this.replicas.size());
+        return this.replicas.get(index);
     }
 
-    // --------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
 
     private void onStartMsg(StartMsg msg) {
         System.out.printf("[C] Client %s started\n", getSelf().path().name());
 
         // Create a timer that will periodically send READ messages to a replica
+        // and then the client will redirect the message to randomly chosen replica
         this.readTimer = getContext().system().scheduler().scheduleWithFixedDelay(
                 Duration.create(1, TimeUnit.SECONDS), // when to start generating messages
                 Duration.create(10, TimeUnit.SECONDS), // how frequently generate them
-                this.getReplica(), // destination actor reference
-                new ReadMsg(), // the message to send
+                getSelf(), // destination actor reference
+                new ReadMsg(null, 0), // the message to send
                 getContext().system().dispatcher(), // system dispatcher
                 getSelf() // source of the message (myself)
         );
 
-        // Create a timer that will periodically send WRITE messages to a replica
+        // Create a timer that will periodically send WRITE messages to self and
+        // then the client will redirect the message to randomly chosen replica
         this.writeTimer = getContext().system().scheduler().scheduleWithFixedDelay(
                 Duration.create(1, TimeUnit.SECONDS),
                 Duration.create(4, TimeUnit.SECONDS),
-                this.getReplica(),
-                new UpdateRequestMsg(this.numberGenerator.nextInt(MAX_INT)),
+                getSelf(),
+                new UpdateRequestMsg(null, 0, 0),
                 getContext().system().dispatcher(),
                 getSelf());
     }
@@ -96,9 +112,54 @@ public class Client extends AbstractActor {
         }
     }
 
+    private void onReadMsg(ReadMsg msg) {
+        ActorRef replica = this.getReplica();
+        ReadMsg readMessage = new ReadMsg(getSender(), this.readIndex++);
+        this.readMsgs.putIfAbsent(readMessage.id, replica);
+        replica.tell(readMessage, getSelf());
+
+        getContext().system().scheduler().scheduleOnce(
+            Duration.create(READOK_TIMEOUT, TimeUnit.MILLISECONDS),
+            getSelf(),
+            new ReadOkReceivedMsg(readMessage.id),
+            getContext().system().dispatcher(),
+            getSelf()
+        );
+    }
+
+    private void onUpdateRequestMsg(UpdateRequestMsg msg) {
+        ActorRef replica = this.getReplica();
+        UpdateRequestMsg updateRequest = new UpdateRequestMsg(
+            getSelf(),
+            this.numberGenerator.nextInt(MAX_INT),
+            this.writeIndex
+        );
+        this.writeMsgs.putIfAbsent(updateRequest.id.index, replica);
+        replica.tell(updateRequest, getSelf());
+
+        getContext().system().scheduler().scheduleOnce(
+            Duration.create(UPDATE_REQUEST_OK_TIMEOUT, TimeUnit.MILLISECONDS),
+            getSelf(),
+            new UpdateRequestOkReceivedMsg(updateRequest.id.index),
+            getContext().system().dispatcher(),
+            getSelf()
+        );
+
+        System.out.printf(
+            "[C] Client %s write req to %s for %d with index %d\n",
+            getSelf().path().name(),
+            replica.path().name(),
+            updateRequest.value,
+            this.writeIndex
+        );
+
+        this.writeIndex++;
+    }
+
     private void onReadOk(ReadOkMsg msg) {
         // Updates client value with the one read from a replica
         this.v = msg.v;
+        this.readMsgs.remove(msg.id);
         System.out.printf(
             "[C] Client %s read done %d\n",
             getSelf().path().name(),
@@ -106,12 +167,56 @@ public class Client extends AbstractActor {
         );
     }
 
+    private void onReadOkReceivedMsg(ReadOkReceivedMsg msg) {
+        ActorRef replica = this.readMsgs.remove(msg.id);
+        if (replica != null) {
+            // The ReadOk msg has not been received, replica crashed
+            // Remove replica from the set of active replicas
+            this.replicas.remove(replica);
+
+            System.out.printf(
+                "[C] Client %s detected replica %s has crashed while waiting for an ACK on read\n",
+                getSelf().path().name(),
+                replica.path().name()
+            );
+        }
+    }
+
+    private void onUpdateRequestOkMsg(UpdateRequestOkMsg msg) {
+        this.writeMsgs.remove(msg.id);
+        System.out.printf(
+            "[C] Client %s write done\n",
+            getSelf().path().name()
+        );
+    }
+
+    private void onUpdateRequestOkReceivedMsg(UpdateRequestOkReceivedMsg msg) {
+        ActorRef replica = this.writeMsgs.remove(msg.index);
+        if (replica != null) {
+            // The UpdateRequestOk msg has not been received, replica crashed
+            // Remove replica from the set of active replicas
+            this.replicas.remove(replica);
+
+            System.out.printf(
+                "[C] Client %s detected replica %s has crashed while waiting for an ACK on update for write %d\n",
+                getSelf().path().name(),
+                replica.path().name(),
+                msg.index
+            );
+        }
+    }
+
     @Override
     public Receive createReceive() {
         return receiveBuilder()
                 .match(StartMsg.class, this::onStartMsg)
                 .match(StopMsg.class, this::onStopMsg)
+                .match(ReadMsg.class, this::onReadMsg)
                 .match(ReadOkMsg.class, this::onReadOk)
+                .match(ReadOkReceivedMsg.class, this::onReadOkReceivedMsg)
+                .match(UpdateRequestMsg.class, this::onUpdateRequestMsg)
+                .match(UpdateRequestOkMsg.class, this::onUpdateRequestOkMsg)
+                .match(UpdateRequestOkReceivedMsg.class, this::onUpdateRequestOkReceivedMsg)
                 .build();
     }
 

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -90,8 +90,12 @@ public class Client extends AbstractActor {
         // - sending of UpdateRequestOk from replica to client
         // Since WriteOks are sent one by one to all replicas, the send delays
         // sums up for each replicas, so the amont of them has to be considered.
+        // To account for the possible execution of the election protocol the
+        // delais for election, coordinator, syncronization and lost update
+        // messages are summed up.
         this.UPDATE_REQUEST_OK_TIMEOUT =
             Delays.MAX_DELAY * 3 + Delays.MAX_DELAY * 2 * this.replicas.size() +
+            Delays.MAX_DELAY * this.replicas.size() * 4 +
             Delays.MAX_DELAY * 5; // For additional safety;
 
         System.out.printf("[C] Client %s created\n", getSelf().path().name());
@@ -111,7 +115,6 @@ public class Client extends AbstractActor {
     }
 
     // -------------------------------------------------------------------------
-
     /**
      * When a `StartMsg` is received the client starts producing read and
      * update requests.

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -34,35 +34,35 @@ public class Client extends AbstractActor {
     private int value;
 
     /**
-     * Index of last `ReadMsg` sent.
+     * Index of last ReadMsg sent.
      */
     private int readIndex;
     /**
-     * Index of last `UpdateRequestMsg` sent.
+     * Index of last UpdateRequestMsg sent.
      */
     private int writeIndex;
     /**
-     * Maps the index of each send `ReadMsg` to the replica it was sent to.
+     * Maps the index of each send ReadMsg to the replica it was sent to.
      */
     private final Map<Integer, ActorRef> readMsgs;
     /**
-     * Maps the index of each send `UpdateRequestMsg` to the replica it was sent
+     * Maps the index of each send UpdateRequestMsg to the replica it was sent
      * to.
      */
     private final Map<Integer, ActorRef> writeMsgs;
 
     /**
-     * A timer that periodically produces a `ReadMsg`.
+     * A timer that periodically produces a ReadMsg.
      */
     private Cancellable readTimer;
     /**
-     * A timer that periodically produces an `UpdateRequestMsg` with a random
+     * A timer that periodically produces an UpdateRequestMsg with a random
      * value.
      */
     private Cancellable writeTimer;
 
     /**
-     * Time to wait before checking for the receipt of an `UpdateRequestOkMsg`.
+     * Time to wait before checking for the receipt of an UpdateRequestOkMsg.
      * Should be used to check for liveness of the replica contacted
      * for an update read request.
      */
@@ -116,7 +116,7 @@ public class Client extends AbstractActor {
 
     // -------------------------------------------------------------------------
     /**
-     * When a `StartMsg` is received the client starts producing read and
+     * When a StartMsg is received the client starts producing read and
      * update requests.
      */
     private void onStartMsg(StartMsg msg) {
@@ -145,7 +145,7 @@ public class Client extends AbstractActor {
     }
 
     /**
-     * When a `StopMsg` is received the client stops producing new requests for
+     * When a StopMsg is received the client stops producing new requests for
      * replicas.
      */
     private void onStopMsg(StopMsg msg) {

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -12,11 +12,8 @@ import akka.actor.Cancellable;
 import akka.actor.Props;
 
 import it.unitn.ds1.models.*;
+import it.unitn.ds1.models.crash_detection.*;
 import scala.concurrent.duration.Duration;
-
-import java.util.ArrayList;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
 public class Client extends AbstractActor {
     // Maximum value to be generated for update messages
@@ -36,8 +33,6 @@ public class Client extends AbstractActor {
     // These two sets are used to track requests sent and waiting for ACK
     private final Map<Integer, ActorRef> readMsgs;
     private final Map<Integer, ActorRef> writeMsgs;
-
-    private final Random numberGenerator;
 
     private Cancellable readTimer;
     private Cancellable writeTimer;

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -12,6 +12,8 @@ import akka.actor.Cancellable;
 import akka.actor.Props;
 
 import it.unitn.ds1.models.*;
+import it.unitn.ds1.models.administratives.StartMsg;
+import it.unitn.ds1.models.administratives.StopMsg;
 import it.unitn.ds1.models.crash_detection.*;
 import it.unitn.ds1.utils.Delays;
 import scala.concurrent.duration.Duration;

--- a/src/main/java/it/unitn/ds1/CrashManager.java
+++ b/src/main/java/it/unitn/ds1/CrashManager.java
@@ -4,9 +4,9 @@ import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.Cancellable;
 import akka.actor.Props;
-import it.unitn.ds1.models.CrashMsg;
-import it.unitn.ds1.models.CrashResponseMsg;
-import it.unitn.ds1.models.StartMsg;
+import it.unitn.ds1.models.administratives.StartMsg;
+import it.unitn.ds1.models.crash_detection.CrashMsg;
+import it.unitn.ds1.models.crash_detection.CrashResponseMsg;
 import scala.concurrent.duration.Duration;
 
 import java.util.ArrayList;

--- a/src/main/java/it/unitn/ds1/CrashManager.java
+++ b/src/main/java/it/unitn/ds1/CrashManager.java
@@ -7,6 +7,7 @@ import akka.actor.Props;
 import it.unitn.ds1.models.administratives.StartMsg;
 import it.unitn.ds1.models.crash_detection.CrashMsg;
 import it.unitn.ds1.models.crash_detection.CrashResponseMsg;
+import it.unitn.ds1.utils.Delays;
 import scala.concurrent.duration.Duration;
 
 import java.util.ArrayList;
@@ -49,11 +50,11 @@ public class CrashManager extends AbstractActor {
         System.out.println("[CM] CrashManager started");
 
         if (this.replicas.size() > this.quorum) {
-            // Periodically sends a crash message to self and then redirect it
+            // Periodically sends a crash message to self and then redirects it
             // to a random replica
             this.crashTimer = getContext().system().scheduler().scheduleWithFixedDelay(
-                    Duration.create(1, TimeUnit.SECONDS), // when to start generating messages
-                    Duration.create(2, TimeUnit.SECONDS), // how frequently generate them
+                    Duration.create(Delays.CRASH_WAIT, TimeUnit.MILLISECONDS),
+                    Duration.create(Delays.CRASH_FREQUENCY, TimeUnit.MILLISECONDS),
                     getSelf(), // destination actor reference
                     new CrashMsg(), // the message to send
                     getContext().system().dispatcher(), // system dispatcher

--- a/src/main/java/it/unitn/ds1/CrashManager.java
+++ b/src/main/java/it/unitn/ds1/CrashManager.java
@@ -42,7 +42,7 @@ public class CrashManager extends AbstractActor {
      */
     private ActorRef getReplica() {
         int index = this.numberGenerator.nextInt(this.replicas.size());
-        return this.replicas.get(index);
+        return this.replicas.get(0);
     }
 
     private void onStartMsg(StartMsg msg) {

--- a/src/main/java/it/unitn/ds1/Replica.java
+++ b/src/main/java/it/unitn/ds1/Replica.java
@@ -17,7 +17,16 @@ import akka.actor.Cancellable;
 import akka.actor.Props;
 
 import it.unitn.ds1.models.*;
+import it.unitn.ds1.models.administratives.JoinGroupMsg;
+import it.unitn.ds1.models.administratives.StartMsg;
 import it.unitn.ds1.models.crash_detection.*;
+import it.unitn.ds1.models.election.CoordinatorMsg;
+import it.unitn.ds1.models.election.ElectionMsg;
+import it.unitn.ds1.models.election.LostUpdatesMsg;
+import it.unitn.ds1.models.election.SynchronizationMsg;
+import it.unitn.ds1.models.update.WriteAckMsg;
+import it.unitn.ds1.models.update.WriteMsg;
+import it.unitn.ds1.models.update.WriteOkMsg;
 import it.unitn.ds1.utils.Delays;
 import it.unitn.ds1.utils.UpdateRequestId;
 import it.unitn.ds1.utils.WriteId;

--- a/src/main/java/it/unitn/ds1/Replica.java
+++ b/src/main/java/it/unitn/ds1/Replica.java
@@ -251,7 +251,7 @@ public class Replica extends AbstractActor {
                 Duration.create(1, TimeUnit.SECONDS),
                 Duration.create(Delays.RECEIVE_HEARTBEAT_TIMEOUT, TimeUnit.MILLISECONDS),
                 getSelf(),
-                new HearbeatReceivedMsg(),
+                new HeartbeatReceivedMsg(),
                 getContext().system().dispatcher(),
                 getSelf()
             );
@@ -860,7 +860,7 @@ public class Replica extends AbstractActor {
      * Checks how much time has elapsed since the last message received
      * from the coordinator. If too much has elapsed, then a crash is detected.
      */
-    private void onHeartbeatReceivedMsg(HearbeatReceivedMsg msg) {
+    private void onHeartbeatReceivedMsg(HeartbeatReceivedMsg msg) {
         long now = new Date().getTime();
         long elapsed = now - this.lastContact;
         if (elapsed > Delays.RECEIVE_HEARTBEAT_TIMEOUT) {
@@ -965,7 +965,7 @@ public class Replica extends AbstractActor {
                 .match(WriteOkMsg.class, this::onWriteOkMsg)
                 .match(ElectionMsg.class, this::onElectionMsg)
                 .match(HeartbeatMsg.class, this::onHeartbeatMsg)
-                .match(HearbeatReceivedMsg.class, this::onHeartbeatReceivedMsg)
+                .match(HeartbeatReceivedMsg.class, this::onHeartbeatReceivedMsg)
                 .match(WriteMsgReceivedMsg.class, this::onWriteMsgTimeoutReceivedMsg)
                 .match(WriteOkReceivedMsg.class, this::onWriteOkTimeoutReceivedMsg)
                 .match(CrashMsg.class, this::onCrashMsg)

--- a/src/main/java/it/unitn/ds1/Utils.java
+++ b/src/main/java/it/unitn/ds1/Utils.java
@@ -3,6 +3,7 @@ package it.unitn.ds1;
 import java.util.Map;
 
 import it.unitn.ds1.models.election.ElectionMsg;
+import it.unitn.ds1.utils.WriteId;
 
 public class Utils {
 
@@ -16,23 +17,42 @@ public class Utils {
      * @param highest The node with (temporarily) the newest update
      * @return The node with the newest update
      */
-    public static Map.Entry<Integer, ElectionMsg.LastUpdate> getNewCoordinatorIndex(
-            Map.Entry<Integer, ElectionMsg.LastUpdate> current, Map.Entry<Integer, ElectionMsg.LastUpdate> highest) {
-        if (current.getValue().epoch > highest.getValue().epoch) {
-            // If the epoch of the current node is higher than the other, this node is the most updated
-            return current;
-        } else if (current.getValue().epoch == highest.getValue().epoch &&
-                current.getValue().writeIndex > highest.getValue().writeIndex) {
-            // If the epoch is the same, but the write index is higher, this node is the most updated
-            return current;
-        } else if (current.getValue().epoch == highest.getValue().epoch &&
-                current.getValue().writeIndex == highest.getValue().writeIndex &&
-                current.getKey() > highest.getKey()) {
-            // If both the epoch and the write index are the same, but this has an higher ID, we choose this one
-            // This is because we need a global rule on what node to choose in case of a tie
+    public static Map.Entry<Integer, WriteId> getNewCoordinatorIndex(
+            Map.Entry<Integer, WriteId> current,
+            Map.Entry<Integer, WriteId> highest
+        ) {
+        // If current is later than highest, returns current since it's more
+        // updated
+        if (!current.getValue().isPriorOrEqualTo(highest.getValue())) {
             return current;
         }
-        // Otherwise, we already have the (temporary) most updated node
+
+        // If current and highest are equal return current if it has a higher ID
+        if (
+            current.getValue().equals(highest.getValue()) &&
+            current.getKey() > highest.getKey()
+        ) {
+            return current;
+        }
+
+        // If none of the above, highest is still the most updated
         return highest;
+
+        //if (current.getValue().epoch > highest.getValue().epoch) {
+        //    // If the epoch of the current node is higher than the other, this node is the most updated
+        //    return current;
+        //} else if (current.getValue().epoch == highest.getValue().epoch &&
+        //        current.getValue().index > highest.getValue().writeIndex) {
+        //    // If the epoch is the same, but the write index is higher, this node is the most updated
+        //    return current;
+        //} else if (current.getValue().epoch == highest.getValue().epoch &&
+        //        current.getValue().writeIndex == highest.getValue().writeIndex &&
+        //        current.getKey() > highest.getKey()) {
+        //    // If both the epoch and the write index are the same, but this has an higher ID, we choose this one
+        //    // This is because we need a global rule on what node to choose in case of a tie
+        //    return current;
+        //}
+        // Otherwise, we already have the (temporary) most updated node
+        //return highest;
     }
 }

--- a/src/main/java/it/unitn/ds1/Utils.java
+++ b/src/main/java/it/unitn/ds1/Utils.java
@@ -7,10 +7,11 @@ import it.unitn.ds1.utils.WriteId;
 public class Utils {
 
     /**
-     * Get the new coordinator from a list of nodes, each with a LastUpdate object, containing the last write applied
-     * by that node.
-     * The node with the highest epoch is chosen. If there is a tie, the node with the highest write index is chosen.
-     * If there is still a tie, the node with the highest ID is chosen.
+     * Get the new coordinator from a list of nodes, each with a WriteId object,
+     * containing the last write applied by that node.
+     * The node with the highest epoch is chosen. If there is a tie, the node
+     * with the highest write index is chosen. If there is still a tie, the node
+     * with the highest ID is chosen.
      *
      * @param current The node we are considering
      * @param highest The node with (temporarily) the newest update

--- a/src/main/java/it/unitn/ds1/Utils.java
+++ b/src/main/java/it/unitn/ds1/Utils.java
@@ -2,7 +2,6 @@ package it.unitn.ds1;
 
 import java.util.Map;
 
-import it.unitn.ds1.models.election.ElectionMsg;
 import it.unitn.ds1.utils.WriteId;
 
 public class Utils {
@@ -37,22 +36,5 @@ public class Utils {
 
         // If none of the above, highest is still the most updated
         return highest;
-
-        //if (current.getValue().epoch > highest.getValue().epoch) {
-        //    // If the epoch of the current node is higher than the other, this node is the most updated
-        //    return current;
-        //} else if (current.getValue().epoch == highest.getValue().epoch &&
-        //        current.getValue().index > highest.getValue().writeIndex) {
-        //    // If the epoch is the same, but the write index is higher, this node is the most updated
-        //    return current;
-        //} else if (current.getValue().epoch == highest.getValue().epoch &&
-        //        current.getValue().writeIndex == highest.getValue().writeIndex &&
-        //        current.getKey() > highest.getKey()) {
-        //    // If both the epoch and the write index are the same, but this has an higher ID, we choose this one
-        //    // This is because we need a global rule on what node to choose in case of a tie
-        //    return current;
-        //}
-        // Otherwise, we already have the (temporary) most updated node
-        //return highest;
     }
 }

--- a/src/main/java/it/unitn/ds1/Utils.java
+++ b/src/main/java/it/unitn/ds1/Utils.java
@@ -1,8 +1,8 @@
 package it.unitn.ds1;
 
-import it.unitn.ds1.models.ElectionMsg;
-
 import java.util.Map;
+
+import it.unitn.ds1.models.election.ElectionMsg;
 
 public class Utils {
 

--- a/src/main/java/it/unitn/ds1/models/ReadMsg.java
+++ b/src/main/java/it/unitn/ds1/models/ReadMsg.java
@@ -2,9 +2,17 @@ package it.unitn.ds1.models;
 
 import java.io.Serializable;
 
+import akka.actor.ActorRef;
+
 /**
  * Sent by the client to the replica, to read the value.
  */
 public class ReadMsg implements Serializable {
-    
+    public final ActorRef client;
+    public final int id;
+
+    public ReadMsg(ActorRef client, int id) {
+        this.client = client;
+        this.id = id;
+    }
 }

--- a/src/main/java/it/unitn/ds1/models/ReadOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/ReadOkMsg.java
@@ -7,8 +7,10 @@ import java.io.Serializable;
  */
 public class ReadOkMsg implements Serializable {
     public final int v;
+    public final int id;
 
-    public ReadOkMsg(int v) {
+    public ReadOkMsg(int v, int id) {
         this.v = v;
+        this.id = id;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/ReadOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/ReadOkMsg.java
@@ -6,11 +6,11 @@ import java.io.Serializable;
  * Sent by the replica to the client, in response to a READ request.
  */
 public class ReadOkMsg implements Serializable {
-    public final int v;
+    public final int value;
     public final int id;
 
-    public ReadOkMsg(int v, int id) {
-        this.v = v;
+    public ReadOkMsg(int value, int id) {
+        this.value = value;
         this.id = id;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/UpdateRequestMsg.java
+++ b/src/main/java/it/unitn/ds1/models/UpdateRequestMsg.java
@@ -16,4 +16,23 @@ public class UpdateRequestMsg implements Serializable {
         this.value = value;
         this.id = new UpdateRequestId(client, index);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof UpdateRequestMsg)) {
+            return false;
+        }
+
+        UpdateRequestMsg other = (UpdateRequestMsg) obj;
+        return this.id.equals(other.id) && this.value == other.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return String.format("%d-%d", this.id.hashCode(), this.value).hashCode();
+    }
 }

--- a/src/main/java/it/unitn/ds1/models/UpdateRequestMsg.java
+++ b/src/main/java/it/unitn/ds1/models/UpdateRequestMsg.java
@@ -2,13 +2,18 @@ package it.unitn.ds1.models;
 
 import java.io.Serializable;
 
+import akka.actor.ActorRef;
+import it.unitn.ds1.utils.UpdateRequestId;
+
 /**
  * Sent by the client to the replica, to update the value.
  */
 public class UpdateRequestMsg implements Serializable {
-    public final int v;
+    public final UpdateRequestId id;
+    public final int value;
 
-    public UpdateRequestMsg(int v) {
-        this.v = v;
+    public UpdateRequestMsg(ActorRef client, int value, int index) {
+        this.value = value;
+        this.id = new UpdateRequestId(client, index);
     }
 }

--- a/src/main/java/it/unitn/ds1/models/UpdateRequestOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/UpdateRequestOkMsg.java
@@ -2,6 +2,11 @@ package it.unitn.ds1.models;
 
 import java.io.Serializable;
 
+/**
+ * This messages is sent by a replica back to client that sent it the
+ * `UpdateRequestMsg` that initiated the update protocol. The message should
+ * contain the index found inside that update request.
+ */
 public class UpdateRequestOkMsg implements Serializable {
     public final int id;
 

--- a/src/main/java/it/unitn/ds1/models/UpdateRequestOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/UpdateRequestOkMsg.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 
 /**
  * This messages is sent by a replica back to client that sent it the
- * `UpdateRequestMsg` that initiated the update protocol. The message should
+ * UpdateRequestMsg that initiated the update protocol. The message should
  * contain the index found inside that update request.
  */
 public class UpdateRequestOkMsg implements Serializable {

--- a/src/main/java/it/unitn/ds1/models/UpdateRequestOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/UpdateRequestOkMsg.java
@@ -1,0 +1,11 @@
+package it.unitn.ds1.models;
+
+import java.io.Serializable;
+
+public class UpdateRequestOkMsg implements Serializable {
+    public final int id;
+
+    public UpdateRequestOkMsg(int id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/WriteAckMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteAckMsg.java
@@ -2,15 +2,16 @@ package it.unitn.ds1.models;
 
 import java.io.Serializable;
 
+import it.unitn.ds1.utils.WriteId;
+
 /**
  * Sent by the replicas, to acknowledge the write operation requested by the coordinator.
  */
 public class WriteAckMsg implements Serializable {
-    public final int epoch; // Epoch of the coordinator
-    public final int writeIndex; // Index of the write operation
+    // ID of WriteMsg to ACK
+    public final WriteId id;
 
-    public WriteAckMsg(int epoch, int writeIndex) {
-        this.epoch = epoch;
-        this.writeIndex = writeIndex;
+    public WriteAckMsg(WriteId id) {
+        this.id = id;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/WriteMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteMsg.java
@@ -11,11 +11,11 @@ import it.unitn.ds1.utils.WriteId;
 public class WriteMsg implements Serializable {
     public final UpdateRequestId updateRequestId;
     public final WriteId id; // Identifier <epoch, index>
-    public final int v; // The new value to write
+    public final int value; // The new value to write
 
-    public WriteMsg(UpdateRequestId updateRequestId, WriteId id, int v) {
+    public WriteMsg(UpdateRequestId updateRequestId, WriteId id, int value) {
         this.updateRequestId = updateRequestId;
         this.id = id;
-        this.v = v;
+        this.value = value;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/WriteMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteMsg.java
@@ -2,17 +2,20 @@ package it.unitn.ds1.models;
 
 import java.io.Serializable;
 
+import it.unitn.ds1.utils.UpdateRequestId;
+import it.unitn.ds1.utils.WriteId;
+
 /**
  * Sent by the coordinator, to write a new value to the replicas.
  */
 public class WriteMsg implements Serializable {
+    public final UpdateRequestId updateRequestId;
+    public final WriteId id; // Identifier <epoch, index>
     public final int v; // The new value to write
-    public final int epoch; // The epoch (current coordinator)
-    public final int writeIndex; // The index of the write operation
 
-    public WriteMsg(int v, int e, int i) {
+    public WriteMsg(UpdateRequestId updateRequestId, WriteId id, int v) {
+        this.updateRequestId = updateRequestId;
+        this.id = id;
         this.v = v;
-        this.epoch = e;
-        this.writeIndex = i;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/WriteOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/WriteOkMsg.java
@@ -2,15 +2,18 @@ package it.unitn.ds1.models;
 
 import java.io.Serializable;
 
+import it.unitn.ds1.utils.UpdateRequestId;
+import it.unitn.ds1.utils.WriteId;
+
 /**
  * Sent by the coordinator, to apply the write operation.
  */
 public class WriteOkMsg implements Serializable {
-    public final int epoch; // The epoch of the coordinator
-    public final int writeIndex; // The index of the write operation
+    public final WriteId id;
+    public final UpdateRequestId updateRequestId;
 
-    public WriteOkMsg(int epoch, int writeIndex) {
-        this.epoch = epoch;
-        this.writeIndex = writeIndex;
+    public WriteOkMsg(WriteId id, UpdateRequestId updateRequestId) {
+        this.id = id;
+        this.updateRequestId = updateRequestId;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/administratives/JoinGroupMsg.java
+++ b/src/main/java/it/unitn/ds1/models/administratives/JoinGroupMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.administratives;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/src/main/java/it/unitn/ds1/models/administratives/StartMsg.java
+++ b/src/main/java/it/unitn/ds1/models/administratives/StartMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.administratives;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/models/administratives/StopMsg.java
+++ b/src/main/java/it/unitn/ds1/models/administratives/StopMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.administratives;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/models/crash_detection/CoordinatorAckReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/CoordinatorAckReceivedMsg.java
@@ -1,0 +1,13 @@
+package it.unitn.ds1.models.crash_detection;
+
+import java.io.Serializable;
+
+import it.unitn.ds1.models.election.CoordinatorMsg;
+
+public class CoordinatorAckReceivedMsg implements Serializable {
+    public final CoordinatorMsg msg;
+
+    public CoordinatorAckReceivedMsg(CoordinatorMsg msg) {
+        this.msg = msg;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/crash_detection/CrashMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/CrashMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.crash_detection;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/models/crash_detection/CrashResponseMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/CrashResponseMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.crash_detection;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/models/crash_detection/ElectionAckReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/ElectionAckReceivedMsg.java
@@ -1,0 +1,13 @@
+package it.unitn.ds1.models.crash_detection;
+
+import java.io.Serializable;
+
+import it.unitn.ds1.models.election.ElectionMsg;
+
+public class ElectionAckReceivedMsg implements Serializable {
+    public final ElectionMsg msg;
+
+    public ElectionAckReceivedMsg(ElectionMsg msg) {
+        this.msg = msg;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/crash_detection/HearbeatReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/HearbeatReceivedMsg.java
@@ -1,0 +1,7 @@
+package it.unitn.ds1.models.crash_detection;
+
+import java.io.Serializable;
+
+public class HearbeatReceivedMsg implements Serializable {
+    
+}

--- a/src/main/java/it/unitn/ds1/models/crash_detection/HeartbeatMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/HeartbeatMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.crash_detection;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/models/crash_detection/HeartbeatReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/HeartbeatReceivedMsg.java
@@ -2,6 +2,6 @@ package it.unitn.ds1.models.crash_detection;
 
 import java.io.Serializable;
 
-public class HearbeatReceivedMsg implements Serializable {
+public class HeartbeatReceivedMsg implements Serializable {
     
 }

--- a/src/main/java/it/unitn/ds1/models/crash_detection/ReadOkReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/ReadOkReceivedMsg.java
@@ -1,0 +1,14 @@
+package it.unitn.ds1.models.crash_detection;
+
+import java.io.Serializable;
+
+public class ReadOkReceivedMsg implements Serializable {
+    /**
+     * Id of the ReadMsg associated to the ReadMsg to check for confirmation.
+     */
+    public final int id;
+
+    public ReadOkReceivedMsg(int id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/crash_detection/UpdateRequestOkReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/UpdateRequestOkReceivedMsg.java
@@ -1,0 +1,11 @@
+package it.unitn.ds1.models.crash_detection;
+
+import java.io.Serializable;
+
+public class UpdateRequestOkReceivedMsg implements Serializable {
+    public final int index;
+
+    public UpdateRequestOkReceivedMsg(int index) {
+        this.index = index;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/crash_detection/WriteMsgReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/WriteMsgReceivedMsg.java
@@ -1,0 +1,12 @@
+package it.unitn.ds1.models.crash_detection;
+
+import java.io.Serializable;
+import java.util.AbstractMap;
+
+public class WriteMsgReceivedMsg implements Serializable {
+    public final AbstractMap.SimpleEntry<Integer, Integer> writeMsg;
+    
+    public WriteMsgReceivedMsg(AbstractMap.SimpleEntry<Integer, Integer> writeMsg) {
+        this.writeMsg = writeMsg;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/crash_detection/WriteMsgReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/WriteMsgReceivedMsg.java
@@ -1,12 +1,14 @@
 package it.unitn.ds1.models.crash_detection;
 
 import java.io.Serializable;
-import java.util.AbstractMap;
+
+import it.unitn.ds1.utils.UpdateRequestId;
 
 public class WriteMsgReceivedMsg implements Serializable {
-    public final AbstractMap.SimpleEntry<Integer, Integer> writeMsg;
+    // UpdateRequest that caused the associated WriteMsg to be generated
+    public final UpdateRequestId updateRequestId;
     
-    public WriteMsgReceivedMsg(AbstractMap.SimpleEntry<Integer, Integer> writeMsg) {
-        this.writeMsg = writeMsg;
+    public WriteMsgReceivedMsg(UpdateRequestId updateRequestId) {
+        this.updateRequestId = updateRequestId;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/crash_detection/WriteOkReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/WriteOkReceivedMsg.java
@@ -1,0 +1,17 @@
+package it.unitn.ds1.models.crash_detection;
+
+import java.io.Serializable;
+import java.util.AbstractMap;
+
+/**
+ * This message is sent by a replica to itself when a timeout expires and if
+ * the requested writeOk message has not been received before this message, then
+ * the coordinator is marked as crashed.
+ */
+public class WriteOkReceivedMsg implements Serializable {
+    public final AbstractMap.SimpleEntry<Integer, Integer> writeMsg;
+
+    public WriteOkReceivedMsg(AbstractMap.SimpleEntry<Integer, Integer> writeMsg) {
+        this.writeMsg = writeMsg;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/crash_detection/WriteOkReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/WriteOkReceivedMsg.java
@@ -1,7 +1,9 @@
 package it.unitn.ds1.models.crash_detection;
 
 import java.io.Serializable;
-import java.util.AbstractMap;
+
+import akka.actor.ActorRef;
+import it.unitn.ds1.utils.WriteId;
 
 /**
  * This message is sent by a replica to itself when a timeout expires and if
@@ -9,9 +11,11 @@ import java.util.AbstractMap;
  * the coordinator is marked as crashed.
  */
 public class WriteOkReceivedMsg implements Serializable {
-    public final AbstractMap.SimpleEntry<Integer, Integer> writeMsg;
+    public final ActorRef client;
+    public final WriteId writeMsgId;
 
-    public WriteOkReceivedMsg(AbstractMap.SimpleEntry<Integer, Integer> writeMsg) {
-        this.writeMsg = writeMsg;
+    public WriteOkReceivedMsg(ActorRef client, WriteId writeMsgId) {
+        this.client = client;
+        this.writeMsgId = writeMsgId;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/election/CoordinatorAckMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/CoordinatorAckMsg.java
@@ -1,0 +1,11 @@
+package it.unitn.ds1.models.election;
+
+import java.io.Serializable;
+
+public class CoordinatorAckMsg implements Serializable {
+    public final int index;
+
+    public CoordinatorAckMsg(int index) {
+        this.index = index;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/election/CoordinatorMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/CoordinatorMsg.java
@@ -3,15 +3,17 @@ package it.unitn.ds1.models.election;
 import java.io.Serializable;
 import java.util.Map;
 
+import it.unitn.ds1.utils.WriteId;
+
 /**
  * Sent when a new coordinator has been chosen after the election algorithm.
  */
 public class CoordinatorMsg implements Serializable {
     public final int coordinatorID;
     public final int senderID;
-    public Map<Integer, ElectionMsg.LastUpdate> participants; // Contains pairs (ReplicaID, LastUpdate)
+    public Map<Integer, WriteId> participants; // Contains pairs (ReplicaID, WriteId)
 
-    public CoordinatorMsg(int coordinatorID, int senderID, Map<Integer, ElectionMsg.LastUpdate> participants) {
+    public CoordinatorMsg(int coordinatorID, int senderID, Map<Integer, WriteId> participants) {
         this.coordinatorID = coordinatorID;
         this.senderID = senderID;
         this.participants = participants;

--- a/src/main/java/it/unitn/ds1/models/election/CoordinatorMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/CoordinatorMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.election;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/src/main/java/it/unitn/ds1/models/election/CoordinatorMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/CoordinatorMsg.java
@@ -9,11 +9,13 @@ import it.unitn.ds1.utils.WriteId;
  * Sent when a new coordinator has been chosen after the election algorithm.
  */
 public class CoordinatorMsg implements Serializable {
+    public final int index;
     public final int coordinatorID;
     public final int senderID;
     public Map<Integer, WriteId> participants; // Contains pairs (ReplicaID, WriteId)
 
-    public CoordinatorMsg(int coordinatorID, int senderID, Map<Integer, WriteId> participants) {
+    public CoordinatorMsg(int index, int coordinatorID, int senderID, Map<Integer, WriteId> participants) {
+        this.index = index;
         this.coordinatorID = coordinatorID;
         this.senderID = senderID;
         this.participants = participants;

--- a/src/main/java/it/unitn/ds1/models/election/ElectionAckMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/ElectionAckMsg.java
@@ -1,0 +1,11 @@
+package it.unitn.ds1.models.election;
+
+import java.io.Serializable;
+
+public class ElectionAckMsg implements Serializable {
+    public final int index;
+
+    public ElectionAckMsg(int index) {
+        this.index = index;
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/election/ElectionMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/ElectionMsg.java
@@ -3,14 +3,16 @@ package it.unitn.ds1.models.election;
 import java.io.Serializable;
 import java.util.*;
 
+import it.unitn.ds1.utils.WriteId;
+
 /**
  * Represents an election message, sent from one replica to the next, collecting
  * replicas' IDs and their last update, to decide a new coordinator.
  */
 public class ElectionMsg implements Serializable {
-  public Map<Integer, LastUpdate> participants; // Contains pairs (ReplicaID, LastUpdate)
+  public Map<Integer, WriteId> participants; // Contains pairs (ReplicaID, LastUpdate)
 
-  public ElectionMsg(int replicaID, LastUpdate lastUpdate) {
+  public ElectionMsg(int replicaID, WriteId lastUpdate) {
     this.participants = new HashMap<>();
     this.participants.put(replicaID, lastUpdate);
   }

--- a/src/main/java/it/unitn/ds1/models/election/ElectionMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/ElectionMsg.java
@@ -10,23 +10,12 @@ import it.unitn.ds1.utils.WriteId;
  * replicas' IDs and their last update, to decide a new coordinator.
  */
 public class ElectionMsg implements Serializable {
-  public Map<Integer, WriteId> participants; // Contains pairs (ReplicaID, LastUpdate)
+  public final int index;
+  public final Map<Integer, WriteId> participants; // Contains pairs (ReplicaID, LastUpdate)
 
-  public ElectionMsg(int replicaID, WriteId lastUpdate) {
+  public ElectionMsg(int index, int replicaID, WriteId lastUpdate) {
+    this.index = index;
     this.participants = new HashMap<>();
     this.participants.put(replicaID, lastUpdate);
-  }
-
-  /**
-   * Epoch and writeIndex of the most recent update for a replica
-   */
-  public static class LastUpdate implements Serializable {
-    public int epoch;
-    public int writeIndex;
-
-    public LastUpdate(int epoch, int writeIndex) {
-      this.epoch = epoch;
-      this.writeIndex = writeIndex;
-    }
   }
 }

--- a/src/main/java/it/unitn/ds1/models/election/ElectionMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/ElectionMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.election;
 
 import java.io.Serializable;
 import java.util.*;

--- a/src/main/java/it/unitn/ds1/models/election/LostUpdatesMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/LostUpdatesMsg.java
@@ -1,8 +1,10 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.election;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+
+import it.unitn.ds1.models.update.WriteMsg;
 
 public class LostUpdatesMsg implements Serializable {
     public List<WriteMsg> missedUpdates = new ArrayList<>();

--- a/src/main/java/it/unitn/ds1/models/election/SynchronizationMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/SynchronizationMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.election;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/models/update/WriteAckMsg.java
+++ b/src/main/java/it/unitn/ds1/models/update/WriteAckMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.update;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/models/update/WriteMsg.java
+++ b/src/main/java/it/unitn/ds1/models/update/WriteMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.update;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/models/update/WriteOkMsg.java
+++ b/src/main/java/it/unitn/ds1/models/update/WriteOkMsg.java
@@ -1,4 +1,4 @@
-package it.unitn.ds1.models;
+package it.unitn.ds1.models.update;
 
 import java.io.Serializable;
 

--- a/src/main/java/it/unitn/ds1/utils/Delays.java
+++ b/src/main/java/it/unitn/ds1/utils/Delays.java
@@ -9,29 +9,47 @@ public interface Delays {
      */
     final int MAX_DELAY = 100;
     /**
-     * Time to wait before checking for the receipt of a `WriteOkMsg`.
+     * Time to wait before checking for the receipt of a WriteOkMsg.
      */
     final long WRITEOK_TIMEOUT = 3000;
     /**
-     * Time to wait before checking for the receipt of a `writeMsg`.
+     * Time to wait before checking for the receipt of a writeMsg.
      */
     final long WRITEMSG_TIMEOUT = 3000;
     /**
-     * Time to wait before sending a new `HeartbeatMsg`. Should be used by the
+     * Time to wait before sending a new HeartbeatMsg. Should be used by the
      * coordinator to demonstrate is liveness.
      */
     final long SEND_HEARTBEAT_TIMEOUT = 50;
     /**
-     * Time to wait before sending a new `HeartbeatMsg`. Should be used by a
+     * Time to wait before sending a new HeartbeatMsg. Should be used by a
      * replica to check when was the last time it was contacted by the
      * coordinator.
      */
     final long RECEIVE_HEARTBEAT_TIMEOUT = 300;
 
     /**
-     * Time to wait before checking for the receipt of a `ReadOkMsg`. Should be
+     * Time to wait before checking for the receipt of a ReadOkMsg. Should be
      * used by clients to check for liveness of the replica contacted for a
      * read request.
      */
     final long READOK_TIMEOUT = 1000;
+
+    /**
+     * Time to wait before checking for the receipt of and ElectionAckMsg.
+     */
+    final long ELECTION_ACK_TIMEOUT = 1000;
+    /**
+     * Time to wait before checking for the receipt of a CoordinatorAckMsg.
+     */
+    final long COORDINATOR_ACK_TIMEOUT = 1000;
+
+    /**
+     * Time to wait before sending the first CrashMsg.
+     */
+    final long CRASH_WAIT = 1000;
+    /**
+     * How often are crash messages sent to replicas?
+     */
+    final long CRASH_FREQUENCY = 2000;
 }

--- a/src/main/java/it/unitn/ds1/utils/Delays.java
+++ b/src/main/java/it/unitn/ds1/utils/Delays.java
@@ -1,0 +1,37 @@
+package it.unitn.ds1.utils;
+
+/**
+ * This interface collects definitions of delays and timeout times. 
+ */
+public interface Delays {
+    /**
+     * Maximum possible delay for sending of messages.
+     */
+    final int MAX_DELAY = 100;
+    /**
+     * Time to wait before checking for the receipt of a `WriteOkMsg`.
+     */
+    final long WRITEOK_TIMEOUT = 3000;
+    /**
+     * Time to wait before checking for the receipt of a `writeMsg`.
+     */
+    final long WRITEMSG_TIMEOUT = 3000;
+    /**
+     * Time to wait before sending a new `HeartbeatMsg`. Should be used by the
+     * coordinator to demonstrate is liveness.
+     */
+    final long SEND_HEARTBEAT_TIMEOUT = 50;
+    /**
+     * Time to wait before sending a new `HeartbeatMsg`. Should be used by a
+     * replica to check when was the last time it was contacted by the
+     * coordinator.
+     */
+    final long RECEIVE_HEARTBEAT_TIMEOUT = 300;
+
+    /**
+     * Time to wait before checking for the receipt of a `ReadOkMsg`. Should be
+     * used by clients to check for liveness of the replica contacted for a
+     * read request.
+     */
+    final long READOK_TIMEOUT = 1000;
+}

--- a/src/main/java/it/unitn/ds1/utils/UpdateRequestId.java
+++ b/src/main/java/it/unitn/ds1/utils/UpdateRequestId.java
@@ -24,11 +24,10 @@ public class UpdateRequestId {
             return true;
         }
 
-        if (!(obj instanceof UpdateRequestId)) {
+        if (!(obj instanceof UpdateRequestId other)) {
             return false;
         }
 
-        UpdateRequestId other = (UpdateRequestId) obj;
         return this.client.equals(other.client) && this.index == other.index;
     }
 

--- a/src/main/java/it/unitn/ds1/utils/UpdateRequestId.java
+++ b/src/main/java/it/unitn/ds1/utils/UpdateRequestId.java
@@ -1,0 +1,39 @@
+package it.unitn.ds1.utils;
+
+import akka.actor.ActorRef;
+
+/**
+ * Class for simpler handling of update requests identifiers.
+ * An update request is identified by the client that produced it and the
+ * local update index of that client.
+ */
+public class UpdateRequestId {
+    // Client that produced the update request
+    public final ActorRef client;
+    // Identifier, local to the client, of the request
+    public final int index;
+
+    public UpdateRequestId(ActorRef client, int index) {
+        this.client = client;
+        this.index = index;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof UpdateRequestId)) {
+            return false;
+        }
+
+        UpdateRequestId other = (UpdateRequestId) obj;
+        return this.client.equals(other.client) && this.index == other.index;
+    }
+
+    @Override
+    public int hashCode() {
+        return String.format("%d-%d", this.client.hashCode(), this.index).hashCode();
+    }
+}

--- a/src/main/java/it/unitn/ds1/utils/Utils.java
+++ b/src/main/java/it/unitn/ds1/utils/Utils.java
@@ -1,8 +1,6 @@
-package it.unitn.ds1;
+package it.unitn.ds1.utils;
 
 import java.util.Map;
-
-import it.unitn.ds1.utils.WriteId;
 
 public class Utils {
 

--- a/src/main/java/it/unitn/ds1/utils/WriteId.java
+++ b/src/main/java/it/unitn/ds1/utils/WriteId.java
@@ -16,7 +16,7 @@ public class WriteId {
      * Checks if this id is precedent or equal to other
      */
     public boolean isPriorOrEqualTo(WriteId other) {
-        return this.epoch < other.epoch || this.epoch == other.epoch && this.index <= other.index;
+        return this.epoch < other.epoch || this.epoch.equals(other.epoch) && this.index <= other.index;
     }
 
     @Override

--- a/src/main/java/it/unitn/ds1/utils/WriteId.java
+++ b/src/main/java/it/unitn/ds1/utils/WriteId.java
@@ -1,5 +1,7 @@
 package it.unitn.ds1.utils;
 
+import java.util.Objects;
+
 /**
  * Class for a simpler handling of write identifiers
  */
@@ -16,7 +18,7 @@ public class WriteId {
      * Checks if this id is precedent or equal to other
      */
     public boolean isPriorOrEqualTo(WriteId other) {
-        return this.epoch < other.epoch || this.epoch.equals(other.epoch) && this.index <= other.index;
+        return this.epoch < other.epoch || Objects.equals(this.epoch, other.epoch) && this.index <= other.index;
     }
 
     @Override
@@ -25,12 +27,11 @@ public class WriteId {
             return true;
         }
 
-        if (!(obj instanceof WriteId)) {
+        if (!(obj instanceof WriteId other)) {
             return false;
         }
 
-        WriteId other = (WriteId) obj;
-        return this.epoch == other.epoch && this.index == other.index;
+        return Objects.equals(this.epoch, other.epoch) && Objects.equals(this.index, other.index);
     }
 
     @Override

--- a/src/main/java/it/unitn/ds1/utils/WriteId.java
+++ b/src/main/java/it/unitn/ds1/utils/WriteId.java
@@ -1,0 +1,40 @@
+package it.unitn.ds1.utils;
+
+/**
+ * Class for a simpler handling of write identifiers
+ */
+public class WriteId {
+    public final Integer epoch;
+    public final Integer index;
+
+    public WriteId(Integer epoch, Integer index) {
+        this.epoch = epoch;
+        this.index = index;
+    }
+
+    /**
+     * Checks if this id is precedent or equal to `other`
+     */
+    public boolean isPriorOrEqualTo(WriteId other) {
+        return this.epoch < other.epoch || this.epoch == other.epoch && this.index <= other.index;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof WriteId)) {
+            return false;
+        }
+
+        WriteId other = (WriteId) obj;
+        return this.epoch == other.epoch && this.index == other.index;
+    }
+
+    @Override
+    public int hashCode() {
+        return String.format("%d-%d", this.epoch, this.index).hashCode();
+    }
+}

--- a/src/main/java/it/unitn/ds1/utils/WriteId.java
+++ b/src/main/java/it/unitn/ds1/utils/WriteId.java
@@ -13,7 +13,7 @@ public class WriteId {
     }
 
     /**
-     * Checks if this id is precedent or equal to `other`
+     * Checks if this id is precedent or equal to other
      */
     public boolean isPriorOrEqualTo(WriteId other) {
         return this.epoch < other.epoch || this.epoch == other.epoch && this.index <= other.index;

--- a/src/test/java/it/unitn/ds1/ElectionTest.java
+++ b/src/test/java/it/unitn/ds1/ElectionTest.java
@@ -63,7 +63,7 @@ public class ElectionTest {
         }
 
         // Then, we start the election algorithm
-        replicas.get(0).tell(new ElectionMsg(4, new ElectionMsg.LastUpdate(0, 2)), replicas.get(4));
+        replicas.get(0).tell(new ElectionMsg(4, new WriteId(0, 2)), replicas.get(4));
 
         // Required to see all output
         //while (replicas.size() > 0) {}

--- a/src/test/java/it/unitn/ds1/ElectionTest.java
+++ b/src/test/java/it/unitn/ds1/ElectionTest.java
@@ -6,6 +6,8 @@ import it.unitn.ds1.models.administratives.JoinGroupMsg;
 import it.unitn.ds1.models.administratives.StartMsg;
 import it.unitn.ds1.models.election.ElectionMsg;
 import it.unitn.ds1.models.update.WriteMsg;
+import it.unitn.ds1.models.update.WriteOkMsg;
+import it.unitn.ds1.utils.UpdateRequestId;
 import it.unitn.ds1.utils.WriteId;
 
 import java.io.IOException;
@@ -23,7 +25,7 @@ public class ElectionTest {
 
         for (int i = 0; i < N_REPLICAS; i++) {
             // Initially the coordinator is the first created replica
-            replicas.add(system.actorOf(Replica.props(i, 0, -1), "replica" + i));
+            replicas.add(system.actorOf(Replica.props(i, 0, 0), "replica" + i));
         }
 
         for (ActorRef replica : replicas) {
@@ -31,13 +33,15 @@ public class ElectionTest {
             replica.tell(new StartMsg(), ActorRef.noSender());
         }
 
+        var client = system.actorOf(Client.props(replicas), "client");
+
         var values = new int[]{1, 2, 3, 4, 5};
 
         // First, let them add the messages to the list
         for (int i = 0; i < values.length; i++) {
             WriteId id = new WriteId(0, i);
             for (var replica : replicas) {
-                replica.tell(new WriteMsg(null, id, values[i]), null);
+                replica.tell(new WriteMsg(new UpdateRequestId(client, i), id, values[i]), null);
             }
         }
 
@@ -46,27 +50,32 @@ public class ElectionTest {
         // 0 has all the updates
         for (int i = 0; i < values.length; i++) {
             WriteId id = new WriteId(0, i);
-            replicas.get(2).tell(new WriteMsg(null, id, values[i]), null);
+            replicas.get(2).tell(new WriteMsg(new UpdateRequestId(client, i), id, values[i]), null);
+            replicas.get(2).tell(new WriteOkMsg(new WriteId(0, i), new UpdateRequestId(client, i)), null);
         }
 
         // 1 and 2 have one less update
         for (int i = 0; i < values.length - 1; i++) {
             WriteId id = new WriteId(0, i);
-            replicas.get(1).tell(new WriteMsg(null, id, values[i]), null);
-            replicas.get(0).tell(new WriteMsg(null, id, values[i]), null);
+            replicas.get(1).tell(new WriteMsg(new UpdateRequestId(client, i), id, values[i]), null);
+            replicas.get(0).tell(new WriteMsg(new UpdateRequestId(client, i), id, values[i]), null);
+            replicas.get(0).tell(new WriteOkMsg(new WriteId(0, i), new UpdateRequestId(client, i)), null);
+            replicas.get(1).tell(new WriteOkMsg(new WriteId(0, i), new UpdateRequestId(client, i)), null);
         }
         // 3 and 4 have two less updates
         for (int i = 0; i < values.length - 2; i++ ){
             WriteId id = new WriteId(0, i);
-            replicas.get(3).tell(new WriteMsg(null, id, values[i]), null);
-            replicas.get(4).tell(new WriteMsg(null, id, values[i]), null);
+            replicas.get(3).tell(new WriteMsg(new UpdateRequestId(client, i), id, values[i]), null);
+            replicas.get(4).tell(new WriteMsg(new UpdateRequestId(client, i), id, values[i]), null);
+            replicas.get(4).tell(new WriteOkMsg(new WriteId(0, i), new UpdateRequestId(client, i)), null);
+            replicas.get(3).tell(new WriteOkMsg(new WriteId(0, i), new UpdateRequestId(client, i)), null);
         }
 
         // Then, we start the election algorithm
         replicas.get(0).tell(new ElectionMsg(0, 4, new WriteId(0, 2)), replicas.get(4));
 
         // Required to see all output
-        //while (replicas.size() > 0) {}
+        while (replicas.size() > 0) {}
 
         System.out.printf(">>> Press ENTER <<<\n");
         try {

--- a/src/test/java/it/unitn/ds1/ElectionTest.java
+++ b/src/test/java/it/unitn/ds1/ElectionTest.java
@@ -63,7 +63,7 @@ public class ElectionTest {
         }
 
         // Then, we start the election algorithm
-        replicas.get(0).tell(new ElectionMsg(4, new WriteId(0, 2)), replicas.get(4));
+        replicas.get(0).tell(new ElectionMsg(0, 4, new WriteId(0, 2)), replicas.get(4));
 
         // Required to see all output
         //while (replicas.size() > 0) {}

--- a/src/test/java/it/unitn/ds1/ElectionTest.java
+++ b/src/test/java/it/unitn/ds1/ElectionTest.java
@@ -3,6 +3,10 @@ package it.unitn.ds1;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import it.unitn.ds1.models.*;
+import it.unitn.ds1.models.administratives.JoinGroupMsg;
+import it.unitn.ds1.models.administratives.StartMsg;
+import it.unitn.ds1.models.election.ElectionMsg;
+import it.unitn.ds1.models.update.WriteMsg;
 import it.unitn.ds1.utils.WriteId;
 
 import java.io.IOException;

--- a/src/test/java/it/unitn/ds1/ElectionTest.java
+++ b/src/test/java/it/unitn/ds1/ElectionTest.java
@@ -2,7 +2,6 @@ package it.unitn.ds1;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import it.unitn.ds1.models.*;
 import it.unitn.ds1.models.administratives.JoinGroupMsg;
 import it.unitn.ds1.models.administratives.StartMsg;
 import it.unitn.ds1.models.election.ElectionMsg;


### PR DESCRIPTION
## Crash detection protocol
Crash detection works by means of periodic checks of arrival of messages.

### Detection of crashed replicas by clients
- Read requests: `ReadMsg`

  Each clients identifies univocally a read request by means of an incrementing
  index that's placed withing the request itself. Upon sending the request to a
  replica, the client registers the sent request into `readMsgs` (maps read
  indexes to replicas) and starts a timeout (`READOK_TIMEOUT`). When the
  timeout expires a `ReadOkReceivedMsg` is sent by the client to itself.

  A client expects to receive a `ReadOkMsg` from the contacted replica and that
  message should contain the read value and the Id of the served read request. On
  arrival, the client removes from `readMsgs` the request with the ID found in
  the `ReadOkMsg`. A `ReadOkReceivedMsg` also contains the ID of the associated
  request and the handler checks if `readMsgs` holds a value. If that's the case,
  then it means that no `ReadOkMsg` has been received so the replica found in the
  map associated to that ID is presumed to be crashed and removed from the list
  of active replicas. Otherwise, if the map has no value it means that the
  request has been served and the replica was fine up to that point.

- Update requests: `UpdateRequestMsg`

  An update request is identified by the `ActorRef` of the client and another
  incrementing ID. Such pair is handled by the `UpdateRequestId` class. As for
  read requests, when a client sends un update to a replica, it registers the
  request and the destination replica in a map (`writeMsgs`) using the ID as key
  and starts a timeout (`UpdateRequestOkReceivedMsg`).

  The replica, once the request has been served, responds with an
  `UpdateRequestOkMsg` holding the index of the served request. On arrival, the
  index found is used to remove the associated value from `writeMsgs` and on
  arrival of the corresponding `UpdateRequestOkMsg` the same check done for
  read requests is performed. So, a no-value means that the request has been
  served and otherwise that the contacted replica has taken too long to answer
  and is identified as crashed.

  On replica side, when an update request is received the ID (pair `<client, index>`)
  is saved in the set `updateRequests`. This ID is also put into all associated
  `WriteMsg`s and `WriteOkMsg`s. When the update protocol terminates and a
  replica receives a `WriteOkMSg`, it takes the update request ID carried by the
  message and checks if it is present into `updateRequests`. If that's the case,
  it means that this replica is the one that has received the request from the
  client and thus it has to send back an ACK, namely an `UpdateRequestOkMsg` to
  that client. This message holds the local update request index of that client.

### Detection of crashed coordinator by replicas

- On update requests: `UpdateRequestMsg`

  When a replica that's not the coordinator receives an update request, forwards
  it to the coordinator and expects to recive back a `WriteMsg`. So, upon forwarding
  the request the replica start a timeout (`WRITEMSG_TIMEOUT`) and registers the
  ID of the request into the `pendingUpdateRequests` set.

  When the coordinator sends a `WriteMsg` it embeds in it the `updateRequestId` of
  the update request that's being served. Upon reception of this message by the
  coordinator, a replica removes the `updateRequestId` from `pendingUpdateRequests`
  and adds the `WriteId` of the message into `writeRequests` to register the serving
  of that write request.

  When `WRITEMSG_TIMEOUT` expires a `WriteMsgReceivedMsg` is sent by the replica to
  itself and if the expected `WriteMsg` has not been received, so if
  `pendingUpdateRequests` has `updateRequestId` in it, the coordinator is considered
  to be crashed. Alive, otherwise.

  On coordinator side, when an `UpdateRequestMsg` is received, the association
  `WriteId->UpdateRequestId`, `WriteId` being a class representing the pair
  `<epoch, write_index>`, is saved into `writesToUpates` maps and is later used
  to build the `WriteOkMsg`s.

- On write message: `WriteMsg`

  When a replica receives a `WriteMsg` it sends an ACK back to the coordinator
  and expects to receive a `WriteOkMsg` in response. So, again a timer
  (`WRITEOK_TIMEOUT`) is set and a `WriteOkReceivedMSg` is sent by a replica to
  itself at expiration. On receipt of a `WriteOk`, the associated `WriteId` is
  removed from `writeRequests` and on receipt of `WriteOkRecivedMsg` the same
  kind of cheks done for the others `ReceivedMsg`s is done. So, if `writeRequests`
  still holds `WriteId`, the request has not been served yet, and the coordinator
  is set to crashed.

  On coordinator side, when enough ACKs are received for a request and the
  corresponing `WriteOkMsg` can be sent, the `WriteId` associated by current
  values for `epoch` and `currentWriteToAck` is used to retrive from
  `writesToUpdates` to `UpdateRequestId` of originating request and such ID is
  put into the `WriteOk`.

### Detection of crashed replicas by coordinator
- On ACK message: `WriteAckMsg`

  Thanks to the assumption on the minimum available number of a replicas, no
  crash check needs to be perfomed by coordinator side on recipt of ACK messages.

## What's left to do
Crash detection fails when an election starts since timers may expires while replicas are active, but busy in the election. So, some solution will have to be put in place.

## Other changes
Instead of using `sleep` to delay messages, akka internal scheduler has been used for a non-blocking solution.