### PR TITLE
Tests/controlled crashes

### DIFF
--- a/src/main/java/it/unitn/ds1/Broadcaster.java
+++ b/src/main/java/it/unitn/ds1/Broadcaster.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 
 public class Broadcaster {
     final static int N_CLIENTS = 1;
-    final static int N_REPLICAS = 4;
+    final static int N_REPLICAS = 7;
 
     public static void main(String[] args) throws InterruptedException {
         final ActorSystem system = ActorSystem.create("project");
@@ -34,6 +34,7 @@ public class Broadcaster {
                     schedule.program(KeyEvents.WRITE_ACK_ALL, false, 1);
                     break;
                 case 1:
+                    
                     break;
                 case 2:
                     schedule.program(KeyEvents.ELECTION_1, false, 1);

--- a/src/main/java/it/unitn/ds1/Broadcaster.java
+++ b/src/main/java/it/unitn/ds1/Broadcaster.java
@@ -8,19 +8,15 @@ import it.unitn.ds1.models.administratives.StopMsg;
 import it.unitn.ds1.models.controlled.CrashForcedMsg;
 import it.unitn.ds1.models.controlled.ReadForcedMsg;
 import it.unitn.ds1.models.controlled.UpdateRequestForcedMsg;
-import it.unitn.ds1.models.election.ElectionAckMsg;
-import it.unitn.ds1.models.election.ElectionMsg;
-import it.unitn.ds1.utils.ElectionId;
 import it.unitn.ds1.utils.KeyEvents;
 import it.unitn.ds1.utils.ProgrammedCrash;
-import it.unitn.ds1.utils.WriteId;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
 public class Broadcaster {
     final static int N_CLIENTS = 1;
-    final static int N_REPLICAS = 3;
+    final static int N_REPLICAS = 4;
 
     public static void main(String[] args) throws InterruptedException {
         final ActorSystem system = ActorSystem.create("project");
@@ -35,10 +31,11 @@ public class Broadcaster {
             // Program crashes for each replica
             switch (i) {
                 case 0:
-                    schedule.program(KeyEvents.READ, true, 1);
+                    // Sends OKs and crashes
+                    schedule.program(KeyEvents.WRITE_ACK_ALL, true, 1);
                     break;
                 case 1:
-                    //schedule.program(KeyEvents.ELECTION_1, true, 1);
+                    schedule.program(KeyEvents.ELECTION_1, true, 1);
                     break;
                 case 2:
                     break;
@@ -117,15 +114,16 @@ public class Broadcaster {
         //sendUpdateRequest(client, replicas.get(1));
 
         // Makes coordinator crash before it can send out a WriteOk
-        //sendUpdateRequest(client, replicas.get(1));
+        sendUpdateRequest(client, replicas.get(1));
         //Thread.sleep(1000);
-        sendReadMsg(client, replicas.get(0));
+        //sendReadMsg(client, replicas.get(0));
 
         Thread.sleep(5000);
         sendReadMsg(client, replicas.get(1));
 
         requestContinue(system, "terminate system");
         system.terminate();
+        System.out.flush();
         System.out.println(">>> System terminated");
     }
 

--- a/src/main/java/it/unitn/ds1/Broadcaster.java
+++ b/src/main/java/it/unitn/ds1/Broadcaster.java
@@ -31,14 +31,15 @@ public class Broadcaster {
             // Program crashes for each replica
             switch (i) {
                 case 0:
-                    // Sends OKs and crashes
+                    schedule.program(KeyEvents.WRITE_ACK_ALL, false, 1);
                     break;
                 case 1:
-                    schedule.program(KeyEvents.READ, false, 1);
                     break;
                 case 2:
+                    schedule.program(KeyEvents.ELECTION_1, false, 1);
                     break;
                 case 3:
+                    schedule.program(KeyEvents.WRITE_OK, true, 1);
                     break;
                 case 4:
                     break;
@@ -63,10 +64,7 @@ public class Broadcaster {
         }
         var client = system.actorOf(Client.controlledProps(replicas), "client");
         
-        // Makes coordinator crash before it can send out a WriteOk
         sendUpdateRequest(client, replicas.get(1));
-        //Thread.sleep(1000);
-        //sendReadMsg(client, replicas.get(0));
 
         Thread.sleep(5000);
         sendReadMsg(client, replicas.get(1));

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -75,7 +75,7 @@ public class Client extends AbstractActor {
         this.writeMsgs = new HashMap<>();
         this.numberGenerator = new Random(System.nanoTime());
 
-        System.out.printf("[C] Client %s created\n", getSelf().path().name());
+        System.out.printf("[C] Client %s created%n", getSelf().path().name());
 
         if (controlledBehaviour) {
             getContext().become(this.createControlled());
@@ -105,7 +105,7 @@ public class Client extends AbstractActor {
      * update requests.
      */
     private void onStartMsg(@SuppressWarnings("unused") StartMsg msg) {
-        System.out.printf("[C] Client %s started\n", getSelf().path().name());
+        System.out.printf("[C] Client %s started%n", getSelf().path().name());
 
         // Create a timer that will periodically send READ messages to a replica
         // and then the client will redirect the message to randomly chosen replica
@@ -134,7 +134,7 @@ public class Client extends AbstractActor {
      * replicas.
      */
     private void onStopMsg(@SuppressWarnings("unused") StopMsg msg) {
-        System.out.printf("[C] Client %s stopped\n", getSelf().path().name());
+        System.out.printf("[C] Client %s stopped%n", getSelf().path().name());
         if (this.readTimer != null) {
             this.readTimer.cancel();
             this.readTimer = null;
@@ -181,7 +181,7 @@ public class Client extends AbstractActor {
         );
 
         System.out.printf(
-            "[C] Client %s write req to %s for %d with index %d\n",
+            "[C] Client %s write req to %s for %d with index %d%n",
             getSelf().path().name(),
             replica.path().name(),
             updateRequest.value,
@@ -196,7 +196,7 @@ public class Client extends AbstractActor {
         this.value = msg.value;
         this.readMsgs.remove(msg.id);
         System.out.printf(
-                "[C] Client %s read done %d\n",
+                "[C] Client %s read done %d%n",
                 getSelf().path().name(),
                 this.value
         );
@@ -211,7 +211,7 @@ public class Client extends AbstractActor {
             this.replicas.remove(replica);
 
             System.out.printf(
-                "[C] Client %s detected replica %s has crashed while waiting for an ACK on read\n",
+                "[C] Client %s detected replica %s has crashed while waiting for an ACK on read%n",
                 getSelf().path().name(),
                 replica.path().name()
             );
@@ -221,7 +221,7 @@ public class Client extends AbstractActor {
     private void onUpdateRequestOkMsg(UpdateRequestOkMsg msg) {
         this.writeMsgs.remove(msg.id);
         System.out.printf(
-            "[C] Client %s write done\n",
+            "[C] Client %s write done%n",
             getSelf().path().name()
         );
     }
@@ -234,7 +234,7 @@ public class Client extends AbstractActor {
             this.replicas.remove(replica);
 
             System.out.printf(
-                "[C] Client %s detected replica %s has crashed while waiting for an ACK on update for write %d\n",
+                "[C] Client %s detected replica %s has crashed while waiting for an ACK on update for write %d%n",
                 getSelf().path().name(),
                 replica.path().name(),
                 msg.index

--- a/src/main/java/it/unitn/ds1/Client.java
+++ b/src/main/java/it/unitn/ds1/Client.java
@@ -28,7 +28,7 @@ public class Client extends AbstractActor {
     static final int MAX_INT = 1000;
 
     /**
-     * All replicas in the system, whether they're active or not.
+     * All the active replicas in the system.
      */
     private final ArrayList<ActorRef> replicas;
     /**

--- a/src/main/java/it/unitn/ds1/CrashManager.java
+++ b/src/main/java/it/unitn/ds1/CrashManager.java
@@ -107,8 +107,6 @@ public class CrashManager extends AbstractActor {
      * the set of known ones). If current behaviour is Controlled, this message
      * is sent to replica until it crashes. Under normal functioning, it's sent
      * just one time and that's it.
-     * 
-     * @param replica Replica to be made crash.
      */
     private void onCrashMsgForced(CrashForcedMsg msg) {
         if (this.replicas.contains(msg.replica)) {

--- a/src/main/java/it/unitn/ds1/CrashManager.java
+++ b/src/main/java/it/unitn/ds1/CrashManager.java
@@ -29,7 +29,7 @@ public class CrashManager extends AbstractActor {
         this.numberGenerator = new Random(System.nanoTime());
 
         System.out.printf(
-                "[CM] Crash manager %s created with a quorum of %d\n",
+                "[CM] Crash manager %s created with a quorum of %d%n",
                 getSelf().path().name(),
                 this.quorum
         );
@@ -78,7 +78,7 @@ public class CrashManager extends AbstractActor {
         ActorRef replica = this.getReplica();
 
         System.out.printf(
-                "[CM] CrashManager sent crash message to %s\n",
+                "[CM] CrashManager sent crash message to %s%n",
                 replica.path().name()
         );
         replica.tell(msg, getSelf());

--- a/src/main/java/it/unitn/ds1/Replica.java
+++ b/src/main/java/it/unitn/ds1/Replica.java
@@ -376,7 +376,7 @@ public class Replica extends AbstractActor {
         getContext().system().scheduler().scheduleOnce(
                 Duration.create(delay, TimeUnit.MILLISECONDS),
                 getSelf(),
-                new StuckedElectionMsg(),
+                new StuckedElectionMsg(this.epoch),
                 getContext().system().dispatcher(),
                 getSelf()
         );
@@ -547,7 +547,7 @@ public class Replica extends AbstractActor {
                 .match(SynchronizationMsg.class, this.electionBehaviour::onSynchronizationMsg)
                 .match(ElectionAckMsg.class, this.electionBehaviour::onElectionAckMsg)
                 .match(ElectionAckReceivedMsg.class, this.electionBehaviour::onElectionAckReceivedMsg)
-                .match(StuckedElectionMsg.class, this.electionBehaviour::onStuckedElectionMsg)
+                //.match(StuckedElectionMsg.class, this.electionBehaviour::onStuckedElectionMsg)
                 .build();
     }
 

--- a/src/main/java/it/unitn/ds1/Replica.java
+++ b/src/main/java/it/unitn/ds1/Replica.java
@@ -547,6 +547,7 @@ public class Replica extends AbstractActor {
                 .match(SynchronizationMsg.class, this.electionBehaviour::onSynchronizationMsg)
                 .match(ElectionAckMsg.class, this.electionBehaviour::onElectionAckMsg)
                 .match(ElectionAckReceivedMsg.class, this.electionBehaviour::onElectionAckReceivedMsg)
+                .match(SynchronizationAckReceivedMsg.class, this.electionBehaviour::onSynchronizationAckReceivedMsg)
                 //.match(StuckedElectionMsg.class, this.electionBehaviour::onStuckedElectionMsg)
                 .build();
     }

--- a/src/main/java/it/unitn/ds1/Replica.java
+++ b/src/main/java/it/unitn/ds1/Replica.java
@@ -535,7 +535,7 @@ public class Replica extends AbstractActor {
                 .match(ElectionMsg.class, this.electionBehaviour::onElectionMsg)
                 .match(SynchronizationMsg.class, this.electionBehaviour::onSynchronizationMsg)
                 .match(ElectionAckMsg.class, this.electionBehaviour::onElectionAckMsg)
-                .match(ElectionAckReceivedMsg.class, this.electionBehaviour::onElectionAckTimeoutReceivedMsg)
+                .match(ElectionAckReceivedMsg.class, this.electionBehaviour::onElectionAckReceivedMsg)
                 .build();
     }
 

--- a/src/main/java/it/unitn/ds1/behaviours/MessageTimeouts.java
+++ b/src/main/java/it/unitn/ds1/behaviours/MessageTimeouts.java
@@ -50,7 +50,7 @@ public class MessageTimeouts {
                 getContext().system().dispatcher(),
                 getSelf()
         );
-        System.out.printf("[Co] Coordinator %s started\n", getSelf().path().name());
+        System.out.printf("[Co] Coordinator %s started%n", getSelf().path().name());
     }
 
     public void startHeartbeatReplicaTimer() {
@@ -64,7 +64,7 @@ public class MessageTimeouts {
                 getSelf()
         );
         this.resetLastContact();
-        System.out.printf("[R] Replica %s started\n", getSelf().path().name());
+        System.out.printf("[R] Replica %s started%n", getSelf().path().name());
     }
 
     /**

--- a/src/main/java/it/unitn/ds1/behaviours/ReplicaElectionBehaviour.java
+++ b/src/main/java/it/unitn/ds1/behaviours/ReplicaElectionBehaviour.java
@@ -318,6 +318,11 @@ public class ReplicaElectionBehaviour {
      * again.
      */
     public void onStuckedElectionMsg(StuckedElectionMsg msg) {
+        if (msg.epoch != thisReplica.getEpoch()) {
+            // The election protocol is active, but for a different election.
+            // The one being checked here must have completed
+            return;
+        }
         this.thisReplica.beginElection();
         this.sendElectionMessage();
 

--- a/src/main/java/it/unitn/ds1/behaviours/ReplicaElectionBehaviour.java
+++ b/src/main/java/it/unitn/ds1/behaviours/ReplicaElectionBehaviour.java
@@ -385,6 +385,14 @@ public class ReplicaElectionBehaviour {
      * contains the list of updates missed by the receiver.
      */
     public void sendAllSynchronizationMessages(Map<Integer, WriteId> lastWriteForReplica) {
+        KeyEvents event = KeyEvents.SYNCHRONIZATION;
+        this.thisReplica.schedule.register(event);
+
+        if (this.thisReplica.schedule.crashBefore(event)) {
+            this.thisReplica.crash(event, true);
+            return;
+        }
+
         for (var entry : lastWriteForReplica.entrySet()) {
             var replica = thisReplica.getReplicas().get(entry.getKey());
             var lastUpdate = entry.getValue();
@@ -401,6 +409,10 @@ public class ReplicaElectionBehaviour {
                     missedUpdatesList
                 )
             );
+        }
+
+        if (this.thisReplica.schedule.crashAfter(event)) {
+            this.thisReplica.crash(event, false);
         }
     }
 

--- a/src/main/java/it/unitn/ds1/behaviours/ReplicaElectionBehaviour.java
+++ b/src/main/java/it/unitn/ds1/behaviours/ReplicaElectionBehaviour.java
@@ -416,7 +416,6 @@ public class ReplicaElectionBehaviour {
 
         if (this.thisReplica.schedule.crashAfter(event)) {
             this.thisReplica.crash(event, false);
-            this.thisReplica.crash(event, false);
         }
     }
 }

--- a/src/main/java/it/unitn/ds1/behaviours/ReplicaElectionBehaviour.java
+++ b/src/main/java/it/unitn/ds1/behaviours/ReplicaElectionBehaviour.java
@@ -312,6 +312,21 @@ public class ReplicaElectionBehaviour {
         );
     }
 
+    /**
+     * If this message is received while the election protocol is active, it
+     * means that somewhere the election got stuck, so it must be restarted
+     * again.
+     */
+    public void onStuckedElectionMsg(StuckedElectionMsg msg) {
+        this.thisReplica.beginElection();
+        this.sendElectionMessage();
+
+        System.out.printf(
+            "[R%d] Detected stucked election, initiating a new one%n",
+            thisReplica.getReplicaID()
+        );
+    }
+
     //=== AUXILIARIES ==========================================================
     public void setElectionUnderway(boolean b) {
         this.isElectionUnderway = b;

--- a/src/main/java/it/unitn/ds1/models/crash_detection/SynchronizationAckReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/SynchronizationAckReceivedMsg.java
@@ -1,0 +1,10 @@
+package it.unitn.ds1.models.crash_detection;
+
+import it.unitn.ds1.models.election.ElectionMsg;
+
+import java.io.Serializable;
+
+public class SynchronizationAckReceivedMsg implements Serializable {
+    public SynchronizationAckReceivedMsg() {
+    }
+}

--- a/src/main/java/it/unitn/ds1/models/crash_detection/SynchronizationAckReceivedMsg.java
+++ b/src/main/java/it/unitn/ds1/models/crash_detection/SynchronizationAckReceivedMsg.java
@@ -1,10 +1,5 @@
 package it.unitn.ds1.models.crash_detection;
 
-import it.unitn.ds1.models.election.ElectionMsg;
-
 import java.io.Serializable;
 
-public class SynchronizationAckReceivedMsg implements Serializable {
-    public SynchronizationAckReceivedMsg() {
-    }
-}
+public class SynchronizationAckReceivedMsg implements Serializable {}

--- a/src/main/java/it/unitn/ds1/models/election/ElectionAckMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/ElectionAckMsg.java
@@ -2,10 +2,12 @@ package it.unitn.ds1.models.election;
 
 import java.io.Serializable;
 
-public class ElectionAckMsg implements Serializable {
-    public final int index;
+import it.unitn.ds1.utils.ElectionId;
 
-    public ElectionAckMsg(int index) {
-        this.index = index;
+public class ElectionAckMsg implements Serializable {
+    public final ElectionId id;
+
+    public ElectionAckMsg(ElectionId id) {
+        this.id = id;
     }
 }

--- a/src/main/java/it/unitn/ds1/models/election/ElectionMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/ElectionMsg.java
@@ -3,6 +3,7 @@ package it.unitn.ds1.models.election;
 import java.io.Serializable;
 import java.util.*;
 
+import it.unitn.ds1.utils.ElectionId;
 import it.unitn.ds1.utils.WriteId;
 
 /**
@@ -10,14 +11,23 @@ import it.unitn.ds1.utils.WriteId;
  * replicas' IDs and their last update, to decide a new coordinator.
  */
 public class ElectionMsg implements Serializable {
-  public final int endingEpoch;
-  public final int index;
+  public final ElectionId id;
   public final Map<Integer, WriteId> participants; // Contains pairs (ReplicaID, LastUpdate)
 
-  public ElectionMsg(int epoch, int index, int replicaID, WriteId lastUpdate) {
-    this.endingEpoch = epoch;
-    this.index = index;
+  public ElectionMsg(int epoch, int replicaID, WriteId lastUpdate, boolean isFirstRound) {
+    this.id = new ElectionId(replicaID, epoch, isFirstRound);
     this.participants = new HashMap<>();
     this.participants.put(replicaID, lastUpdate);
+  }
+
+  /**
+   * This constructor should only be used when an election messages passes
+   * from the first to the second round. All the information of the original
+   * messages are mainteined except for the round, which is set to false.
+   * @param msg first round election message
+   */
+  public ElectionMsg(ElectionMsg msg) {
+    this.id = new ElectionId(msg.id.initiator, msg.id.epoch, false);
+    this.participants = msg.participants;
   }
 }

--- a/src/main/java/it/unitn/ds1/models/election/StuckedElectionMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/StuckedElectionMsg.java
@@ -1,0 +1,7 @@
+package it.unitn.ds1.models.election;
+
+import java.io.Serializable;
+
+public class StuckedElectionMsg implements Serializable {
+    
+}

--- a/src/main/java/it/unitn/ds1/models/election/StuckedElectionMsg.java
+++ b/src/main/java/it/unitn/ds1/models/election/StuckedElectionMsg.java
@@ -3,5 +3,13 @@ package it.unitn.ds1.models.election;
 import java.io.Serializable;
 
 public class StuckedElectionMsg implements Serializable {
-    
+    /**
+     * Epoch that should be closed by the election associated to this
+     * message.
+     */
+    public final int epoch;
+
+    public StuckedElectionMsg(int epoch) {
+        this.epoch = epoch;
+    }
 }

--- a/src/main/java/it/unitn/ds1/utils/Delays.java
+++ b/src/main/java/it/unitn/ds1/utils/Delays.java
@@ -44,7 +44,7 @@ public interface Delays {
     /**
      * Time to wait before checking for the receipt of and ElectionAckMsg.
      */
-    long ELECTION_ACK_TIMEOUT = 1000;
+    long ELECTION_ACK_TIMEOUT = 2000;
     /**
      * Time to wait before checking for the receipt of a CoordinatorAckMsg.
      */

--- a/src/main/java/it/unitn/ds1/utils/Delays.java
+++ b/src/main/java/it/unitn/ds1/utils/Delays.java
@@ -44,7 +44,7 @@ public interface Delays {
     /**
      * Time to wait before checking for the receipt of and ElectionAckMsg.
      */
-    long ELECTION_ACK_TIMEOUT = 2000;
+    long ELECTION_ACK_TIMEOUT = 500;
     /**
      * Time to wait before checking for the receipt of a CoordinatorAckMsg.
      */

--- a/src/main/java/it/unitn/ds1/utils/ElectionId.java
+++ b/src/main/java/it/unitn/ds1/utils/ElectionId.java
@@ -1,0 +1,54 @@
+package it.unitn.ds1.utils;
+
+public class ElectionId {
+    /**
+     * ID of the replica who started this election.
+     */
+    public final Integer initiator;
+    /**
+     * Epoch that will be closed when this election completes.
+     */
+    public final Integer epoch;
+    /**
+     * Each election message does two rounds. In the first one each replica
+     * adds itself to the list of participants. In the second each of them
+     * checks if it's become the new coordinator.
+     */
+    public final Boolean isFirstRound;
+
+    public ElectionId(int initiator, int epoch, boolean isFirstRound) {
+        this.initiator = initiator;
+        this.epoch = epoch;
+        this.isFirstRound = isFirstRound;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj == this) {
+            return true;
+        }
+
+        if (!(obj instanceof ElectionId)) {
+            return false;
+        }
+
+        ElectionId other = (ElectionId) obj;
+        return this.initiator == other.initiator &&
+            this.epoch == other.epoch &&
+            this.isFirstRound == other.isFirstRound;
+    }
+
+    @Override
+    public int hashCode() {
+        return String.format(
+            "%d-%d-%d",
+            this.initiator.hashCode(),
+            this.epoch.hashCode(),
+            this.isFirstRound.hashCode()
+        ).hashCode();
+    }
+}

--- a/src/main/java/it/unitn/ds1/utils/KeyEvents.java
+++ b/src/main/java/it/unitn/ds1/utils/KeyEvents.java
@@ -25,7 +25,7 @@ public enum KeyEvents {
      */
     WRITE_ACK_ALL,
     /**
-     * Receipt of a WriteOk.
+     * Receipt of a WriteOk for a normal replica.
      */
     WRITE_OK,
     /** 
@@ -34,7 +34,7 @@ public enum KeyEvents {
      */
     ELECTION_1,
     /** 
-     * Receipt of an election message for the second time.
+     * Receipt of a second-round election message.
      */
     ELECTION_2,
     /**

--- a/src/main/java/it/unitn/ds1/utils/KeyEvents.java
+++ b/src/main/java/it/unitn/ds1/utils/KeyEvents.java
@@ -1,0 +1,64 @@
+package it.unitn.ds1.utils;
+
+/**
+ * These are all the key events in the system.
+ */
+public enum KeyEvents {
+    /**
+     * Actor creation.
+     */
+    CREATION,
+    /**
+     * Receipt of a StartMsg.
+     */
+    START,
+    /**
+     * Receipt of a read request.
+     */
+    READ,
+    /**
+     * Receipt of an update request.
+     */
+    UPDATE,
+    /**
+     * Receipt of a WriteMsg.
+     */
+    WRITE_MSG,
+    /**
+     * Receipt of a WriteACK.
+     */
+    WRITE_ACK,
+    /**
+     * Receipt of all WriteAcks necessary to trigger a WriteOk.
+     */
+    WRITE_ACK_ALL,
+    /**
+     * Receipt of a WriteOk.
+     */
+    WRITE_OK,
+    /** 
+     * Receipt of an election message for the first time, starting the election
+     * protocol.
+     */
+    ELECTION_1,
+    /** 
+     * Receipt of an election message for the second time.
+     */
+    ELECTION_2,
+    /**
+     * Receipt of an ElectionAck.
+     */
+    ELECTION_ACK,
+    /**
+     * Another replica has been choosen as coordinator.
+     */
+    COORDINATOR_CHOOSEN,
+    /**
+     * This replica has become the new coordinator.
+     */
+    COORDINATOR_BECOME,
+    /**
+     * Receipt of a Synchronization message
+     */
+    SYNCHRONIZATION,
+}

--- a/src/main/java/it/unitn/ds1/utils/KeyEvents.java
+++ b/src/main/java/it/unitn/ds1/utils/KeyEvents.java
@@ -5,14 +5,6 @@ package it.unitn.ds1.utils;
  */
 public enum KeyEvents {
     /**
-     * Actor creation.
-     */
-    CREATION,
-    /**
-     * Receipt of a StartMsg.
-     */
-    START,
-    /**
      * Receipt of a read request.
      */
     READ,
@@ -50,13 +42,9 @@ public enum KeyEvents {
      */
     ELECTION_ACK,
     /**
-     * Another replica has been choosen as coordinator.
-     */
-    COORDINATOR_CHOOSEN,
-    /**
      * This replica has become the new coordinator.
      */
-    COORDINATOR_BECOME,
+    BECOME_COORDINATOR,
     /**
      * Receipt of a Synchronization message
      */

--- a/src/main/java/it/unitn/ds1/utils/KeyEvents.java
+++ b/src/main/java/it/unitn/ds1/utils/KeyEvents.java
@@ -28,9 +28,13 @@ public enum KeyEvents {
      * Receipt of a WriteOk for a normal replica.
      */
     WRITE_OK,
+    /**
+     * Sending of a new election message which initiates a new election.
+     */
+    ELECTION_0,
     /** 
      * Receipt of an election message for the first time, starting the election
-     * protocol.
+     * protocol
      */
     ELECTION_1,
     /** 

--- a/src/main/java/it/unitn/ds1/utils/Logger.java
+++ b/src/main/java/it/unitn/ds1/utils/Logger.java
@@ -22,7 +22,7 @@ public class Logger {
 
     private static void log(String message) {
         try {
-            Files.write(Paths.get(FILE_NAME), message.getBytes(), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+            Files.write(Paths.get(FILE_NAME), message.getBytes(), StandardOpenOption.WRITE, StandardOpenOption.CREATE);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/it/unitn/ds1/utils/ProgrammedCrash.java
+++ b/src/main/java/it/unitn/ds1/utils/ProgrammedCrash.java
@@ -1,0 +1,53 @@
+package it.unitn.ds1.utils;
+
+import java.util.HashMap;
+
+/**
+ * This class allows to program the happening of a crash, boundint it 
+ */
+public class ProgrammedCrash {
+    private final HashMap<KeyEvents, Integer> targets;
+    private final HashMap<KeyEvents, Boolean> befores;
+
+    public ProgrammedCrash() {
+        this.targets = new HashMap<>();
+        this.befores = new HashMap<>();
+    }
+
+    /**
+     * Programs a new crash for event.
+     * @param event key event which triggers the crash
+     * @param before should the crash happen before of after the event is served?
+     * @param target how many times should the event occur before triggering a crash?
+     */
+    public void program(KeyEvents event, boolean before, int target) {
+        this.targets.put(event, target);
+        this.befores.put(event, before);
+    }
+
+    /**
+     * Register the happening of an event.
+     */
+    public void register(KeyEvents event) {
+        int target = this.targets.getOrDefault(event, 0);
+        target--;
+                
+        if (target >= 0) {
+            this.targets.put(event, target);
+        }
+    }
+
+    /**
+     * The crash should happen before or after the event is served?
+     */
+    public boolean isBefore(KeyEvents event) {
+        return this.befores.getOrDefault(event, true);
+    }
+
+    /**
+     * Has the event happened enough times to trigger a crash?
+     */
+    public boolean isTargetReached(KeyEvents event) {
+        return this.targets.getOrDefault(event, 1) == 0;
+    }
+}

--- a/src/main/java/it/unitn/ds1/utils/ProgrammedCrash.java
+++ b/src/main/java/it/unitn/ds1/utils/ProgrammedCrash.java
@@ -40,14 +40,30 @@ public class ProgrammedCrash {
     /**
      * The crash should happen before or after the event is served?
      */
-    public boolean isBefore(KeyEvents event) {
+    private boolean isBefore(KeyEvents event) {
         return this.befores.getOrDefault(event, true);
     }
 
     /**
      * Has the event happened enough times to trigger a crash?
      */
-    public boolean isTargetReached(KeyEvents event) {
+    private boolean isTargetReached(KeyEvents event) {
         return this.targets.getOrDefault(event, 1) == 0;
+    }
+
+    /**
+     * Returns true if this replica should crash immediately before serving
+     * this event.
+     */
+    public boolean crashBefore(KeyEvents event) {
+        return this.isTargetReached(event) && this.isBefore(event);
+    }
+
+    /**
+     * Returns true if this replica should crash immediately after serving
+     * this event.
+     */
+    public boolean crashAfter(KeyEvents event) {
+        return this.isTargetReached(event) && !this.isBefore(event);
     }
 }

--- a/src/test/java/it/unitn/ds1/ElectionTest.java
+++ b/src/test/java/it/unitn/ds1/ElectionTest.java
@@ -9,7 +9,6 @@ import it.unitn.ds1.models.controlled.ReadForcedMsg;
 import it.unitn.ds1.models.controlled.UpdateRequestForcedMsg;
 import it.unitn.ds1.models.update.WriteMsg;
 import it.unitn.ds1.models.update.WriteOkMsg;
-import it.unitn.ds1.utils.KeyEvents;
 import it.unitn.ds1.utils.ProgrammedCrash;
 import it.unitn.ds1.utils.UpdateRequestId;
 import it.unitn.ds1.utils.WriteId;

--- a/src/test/java/it/unitn/ds1/ElectionTest.java
+++ b/src/test/java/it/unitn/ds1/ElectionTest.java
@@ -9,6 +9,8 @@ import it.unitn.ds1.models.controlled.ReadForcedMsg;
 import it.unitn.ds1.models.controlled.UpdateRequestForcedMsg;
 import it.unitn.ds1.models.update.WriteMsg;
 import it.unitn.ds1.models.update.WriteOkMsg;
+import it.unitn.ds1.utils.KeyEvents;
+import it.unitn.ds1.utils.ProgrammedCrash;
 import it.unitn.ds1.utils.UpdateRequestId;
 import it.unitn.ds1.utils.WriteId;
 import org.junit.Test;
@@ -20,13 +22,38 @@ public class ElectionTest {
     @Test
     public void testElection() throws InterruptedException {
         final ActorSystem system = ActorSystem.create("electionTest");
-        final int N_REPLICAS = 5;
+        final int N_REPLICAS = 7;
 
         final ArrayList<ActorRef> replicas = new ArrayList<>();
+        int value = 0;
+        // Initially the coordinator is the first created replica
+        int coordinatorIndex = 0;
 
         for (int i = 0; i < N_REPLICAS; i++) {
-            // Initially the coordinator is the first created replica
-            replicas.add(system.actorOf(Replica.props(i, 0, 0), "replica" + i));
+            ProgrammedCrash schedule = new ProgrammedCrash();
+
+            // Program crashes for each replica
+            switch (i) {
+                case 0:
+                    break;
+                case 1:
+                    //schedule.program(KeyEvents.ELECTION_1, false, 1);
+                    break;
+                case 2:
+                    //schedule.program(KeyEvents.ELECTION_1, true, 1);
+                    break;
+                case 3:
+                    break;
+                case 4:
+                    break;
+            }
+
+            replicas.add(system.actorOf(Replica.props(
+                i,
+                value,
+                coordinatorIndex,
+                schedule
+            ), "replica" + i));
         }
 
         for (ActorRef replica : replicas) {
@@ -78,7 +105,7 @@ public class ElectionTest {
         // Then, we start the election algorithm
         makeReplicaCrash(crashManager, replicas.get(0));
         
-        Thread.sleep(2000);
+        Thread.sleep(5000);
         sendReadMsg(client, replicas.get(1));
         sendReadMsg(client, replicas.get(2));
         sendReadMsg(client, replicas.get(3));
@@ -94,7 +121,7 @@ public class ElectionTest {
         // Required to see all output
         while (replicas.size() > 0) {}
 
-        System.out.printf(">>> Press ENTER <<<\n");
+        System.out.printf(">>> Press ENTER <<<%n");
         try {
             System.in.read();
         } catch (IOException ioe) {


### PR DESCRIPTION
Implemented programmable crashes with a mask-like approach. The `ProgramedCrash` class has two hashmaps s.t. for a given `KeyEvent` one can tell on what occurence of that event a crash has to happen. That crash che happen immediately before or after serving that event.

While implementing this another critical problem with election has been addressed. Since an election message can go around each replica up to two times. one has to distinguish these two election messages because two distinct ACK has to be received. This wasn't possible with the previous implementation. Here the problem has been solved by adding a flag into `ElectionId` which allows distinguishing an election message on round one (so a message which is still collection active replicas information), from an election message on round two (so a message which has all information and from which a coordination can be selected).

The only major problem that still has to be solved is again on election. If no replica crashes election work just fine. Otherwise it remains stuck on ACKs.

Another problem with crashes is for event `KeyEvent.WRITE_ACK_ALL`, even if crash should happen before replicas still applies the update, so the `WriteOk`  is sent event if it should not.